### PR TITLE
Fix ARM builds compiling the NEON matrix renderer to an empty stub

### DIFF
--- a/src/renderer/ear/arch/arm/matrix_render_arm.c
+++ b/src/renderer/ear/arch/arm/matrix_render_arm.c
@@ -11,6 +11,7 @@
  */
 
 
+#include "matrix_render.h"
 #if defined(def_oar_arch_arm)
 #include <arm_neon.h>
 


### PR DESCRIPTION

`matrix_render_arm.c` guards its entire body with `#if defined(def_oar_arch_arm)`, but that macro is derived from `__ARM_NEON` in `matrix_render.h` — which this file never includes. On ARM builds the macro is therefore undefined in this translation unit and `multiply_channels_by_matrix_neon()` is preprocessed away to an empty stub: every matrix render (all multichannel downmix (M2M) and HOA-to-loudspeaker (H2M) paths) writes no output samples and renders silence. Only native-layout passthrough, which needs no matrix multiply, works. x86 builds are unaffected (they take the scalar C path), and OBR's binaural path does not use this renderer.

The fix is to include `matrix_render.h` before the arch guard, so the NEON implementation is actually compiled in on ARM.

## Testing

- Built on Apple Silicon (arm64): `multiply_channels_by_matrix_neon` is now present as a real symbol in the object file (previously the TU compiled to nothing).
- `test_channel_based_rendering` and `test_scene_based_rendering` produce non-silent output on arm64.
