### PR TITLE
Fix OBR resampler downsampling errors and rate-dependent binaural loudness

### DIFF
--- a/src/renderer/obr/obr_capi/obr/CMakeLists.txt
+++ b/src/renderer/obr/obr_capi/obr/CMakeLists.txt
@@ -280,6 +280,10 @@ add_executable(sample_type_conversion_test obr/ambisonic_binaural_decoder/tests/
 target_link_libraries(sample_type_conversion_test PRIVATE obr GTest::gtest_main)
 add_test(NAME sample_type_conversion_test COMMAND sample_type_conversion_test)
 
+add_executable(sh_hrir_creator_test obr/ambisonic_binaural_decoder/tests/sh_hrir_creator_test.cc)
+target_link_libraries(sh_hrir_creator_test PRIVATE obr GTest::gtest_main)
+add_test(NAME sh_hrir_creator_test COMMAND sh_hrir_creator_test)
+
 # Ambisonic encoder tests.
 add_executable(ambisonic_encoder_test obr/ambisonic_encoder/tests/ambisonic_encoder_test.cc)
 target_link_libraries(ambisonic_encoder_test PRIVATE test_util GTest::gtest_main)
@@ -337,6 +341,7 @@ set_tests_properties(
     planar_interleaved_conversion_test
     resampler_test
     sample_type_conversion_test
+    sh_hrir_creator_test
     ambisonic_encoder_test
     associated_legendre_polynomials_generator_test
     ambisonic_rotator_test

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/BUILD
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/BUILD
@@ -101,6 +101,7 @@ cc_library(
         ":wav",
         "//obr/ambisonic_binaural_decoder/binaural_filters:binaural_filters_wrapper",
         "//obr/audio_buffer",
+        "//obr/audio_buffer:simd_utils",
         "//obr/common",
         "@abseil-cpp//absl/log:absl_check",
         "@abseil-cpp//absl/log:absl_log",

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/resampler.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/resampler.cc
@@ -269,9 +269,14 @@ void Resampler::GenerateInterpolatingFilter(int sample_rate) {
                      filter_length, filter_channel);
 
   // Pad out the filter length so that it can be arranged in polyphase fashion.
+  // The polyphase decomposition has |up_rate_| branches, so the per-branch
+  // length must be derived from |up_rate_|. Deriving it from |max_rate| (as
+  // previously done) silently dropped the tail of the filter whenever
+  // down_rate_ > up_rate_, causing rate-dependent gain errors (e.g. -2.5 dB at
+  // 96k->48k, -35 dB at 192k->48k) and degraded anti-aliasing.
   const size_t transposed_length =
-      filter_length + max_rate - (filter_length % max_rate);
-  coeffs_per_phase_ = transposed_length / max_rate;
+      filter_length + up_rate_ - (filter_length % up_rate_);
+  coeffs_per_phase_ = transposed_length / up_rate_;
   ArrangeFilterAsPolyphase(filter_length, *filter_channel);
 }
 

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/resampler.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/resampler.cc
@@ -127,16 +127,21 @@ void Resampler::Process(const AudioBuffer& input, AudioBuffer* output) {
   const int samples_left_in_input =
       static_cast<int>(coeffs_per_phase_) - 1 - static_cast<int>(input_length);
   if (samples_left_in_input > 0) {
+    // The live state occupies the first `coeffs_per_phase_` - 1 frames of the
+    // (larger, preallocated) `state_` buffer, so it must be addressed relative
+    // to begin(), not end(). Shift the old state down by `input_length` and
+    // append the entire input, keeping the most recent input samples in
+    // chronological order.
+    const size_t state_num_frames = coeffs_per_phase_ - 1;
     for (size_t channel = 0; channel < num_channels_; ++channel) {
-      // Copy end of the `state_` buffer to the beginning.
       auto& state_channel = state_[channel];
       ABSL_DCHECK_GE(static_cast<int>(state_channel.size()),
                      samples_left_in_input);
-      std::copy_n(state_channel.end() - samples_left_in_input,
-                  samples_left_in_input, state_channel.begin());
-      // Then copy input to the end of the buffer.
+      std::copy(state_channel.begin() + input_length,
+                state_channel.begin() + state_num_frames,
+                state_channel.begin());
       std::copy_n(input[channel].begin(), input_length,
-                  state_channel.end() - input_length);
+                  state_channel.begin() + (state_num_frames - input_length));
     }
   } else {
     for (size_t channel = 0; channel < num_channels_; ++channel) {

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/sh_hrir_creator.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/sh_hrir_creator.cc
@@ -25,6 +25,7 @@
 #include "obr/ambisonic_binaural_decoder/resampler.h"
 #include "obr/ambisonic_binaural_decoder/wav.h"
 #include "obr/audio_buffer/audio_buffer.h"
+#include "obr/audio_buffer/simd_utils.h"
 #include "obr/common/ambisonic_utils.h"
 
 namespace obr {
@@ -57,6 +58,20 @@ std::unique_ptr<AudioBuffer> CreateShHrirsFromWav(const Wav& wav,
     std::unique_ptr<AudioBuffer> resampled_sh_hrirs(new AudioBuffer(
         num_channels, resampler->GetNextOutputLength(sh_hrir_length)));
     resampler->Process(*sh_hrirs, resampled_sh_hrirs.get());
+    // The resampler preserves the waveform of the impulse responses, but the
+    // gain of the filter realized by discrete convolution is proportional to
+    // the rate at which that waveform is sampled: convolving at the target
+    // rate accumulates target/wav times as many taps of the same continuous
+    // curve. Rescale so the realized frequency response - and thus the
+    // rendered loudness - is invariant to the target rate.
+    const float filter_gain_compensation =
+        static_cast<float>(wav_sample_rate_hz) /
+        static_cast<float>(target_sample_rate_hz);
+    for (size_t channel = 0; channel < num_channels; ++channel) {
+      auto& resampled_channel = (*resampled_sh_hrirs)[channel];
+      ScalarMultiply(resampled_channel.size(), filter_gain_compensation,
+                     resampled_channel.begin(), resampled_channel.begin());
+    }
     return resampled_sh_hrirs;
   }
   return sh_hrirs;

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/BUILD
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/BUILD
@@ -82,3 +82,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "sh_hrir_creator_test",
+    srcs = ["sh_hrir_creator_test.cc"],
+    deps = [
+        "//obr/ambisonic_binaural_decoder:resampler",
+        "//obr/ambisonic_binaural_decoder:sh_hrir_creator",
+        "//obr/audio_buffer",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
@@ -12,6 +12,7 @@
 
 #include "obr/ambisonic_binaural_decoder/resampler.h"
 
+#include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
@@ -111,6 +112,51 @@ TEST(ResamplerTest, DownSampleTest) {
   const int num_expected_zero_crossings =
       4 * kToneFrequency / (kSourceDataSampleRate / kInputBufferLength);
   EXPECT_EQ(num_expected_zero_crossings, zero_cross_count);
+}
+
+// Regression test: the polyphase decomposition previously derived its
+// per-branch length from max(up_rate_, down_rate_) although the decomposition
+// has up_rate_ branches. Whenever down_rate_ > up_rate_ this silently dropped
+// the tail of the interpolation filter, causing rate-pair-dependent gain
+// errors (-2.5 dB at 96k->48k, -35 dB at 192k->48k, -41 dB at 176.4k->48k)
+// and degraded anti-aliasing. A unit-amplitude passband tone must come out at
+// unit amplitude for every supported rate pair.
+TEST(ResamplerTest, PassbandGainIsUnityAcrossRatePairs) {
+  const std::pair<int, int> kRatePairs[] = {
+      {44100, 48000},  {48000, 44100},  {88200, 48000}, {96000, 48000},
+      {176400, 48000}, {192000, 48000}, {48000, 96000}};
+  for (const auto& rates : kRatePairs) {
+    const int source_rate = rates.first;
+    const int destination_rate = rates.second;
+    ASSERT_TRUE(
+        Resampler::AreSampleRatesSupported(source_rate, destination_rate));
+
+    // 100 ms of a unit-amplitude tone well inside every passband.
+    const size_t input_length = static_cast<size_t>(source_rate / 10);
+    AudioBuffer input(kNumMonoChannels, input_length);
+    GenerateSineWave(kToneFrequency, source_rate, &input[0]);
+
+    Resampler resampler;
+    resampler.SetRateAndNumChannels(source_rate, destination_rate,
+                                    kNumMonoChannels);
+    AudioBuffer output(kNumMonoChannels,
+                       resampler.GetNextOutputLength(input_length));
+    resampler.Process(input, &output);
+
+    // Amplitude from the RMS of the middle half of the output, which skips
+    // the filter warm-up and tail transients.
+    const size_t begin = output.num_frames() / 4;
+    const size_t end = 3 * output.num_frames() / 4;
+    double sum_squares = 0.0;
+    for (size_t i = begin; i < end; ++i) {
+      sum_squares += static_cast<double>(output[0][i]) * output[0][i];
+    }
+    const double amplitude =
+        std::sqrt(2.0 * sum_squares / static_cast<double>(end - begin));
+    // +-0.012 is roughly +-0.1 dB.
+    EXPECT_NEAR(1.0, amplitude, 0.012)
+        << "gain error for " << source_rate << " -> " << destination_rate;
+  }
 }
 
 TEST(ResamplerTest, ResetStateTest) {

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
@@ -159,6 +159,46 @@ TEST(ResamplerTest, PassbandGainIsUnityAcrossRatePairs) {
   }
 }
 
+// The truncated filter tail also degraded anti-aliasing when downsampling: a
+// tone above the destination Nyquist frequency must be strongly attenuated,
+// not folded back into the output band.
+TEST(ResamplerTest, DownsamplingAttenuatesAboveDestinationNyquist) {
+  // {source_rate, destination_rate, tone_frequency}; each tone sits at 1.5x
+  // the destination Nyquist frequency.
+  const int kCases[][3] = {
+      {96000, 48000, 36000}, {192000, 48000, 72000}, {88200, 44100, 33000}};
+  for (const auto& test_case : kCases) {
+    const int source_rate = test_case[0];
+    const int destination_rate = test_case[1];
+    const int tone_frequency = test_case[2];
+
+    const size_t input_length = static_cast<size_t>(source_rate / 10);
+    AudioBuffer input(kNumMonoChannels, input_length);
+    GenerateSineWave(static_cast<float>(tone_frequency), source_rate,
+                     &input[0]);
+
+    Resampler resampler;
+    resampler.SetRateAndNumChannels(source_rate, destination_rate,
+                                    kNumMonoChannels);
+    AudioBuffer output(kNumMonoChannels,
+                       resampler.GetNextOutputLength(input_length));
+    resampler.Process(input, &output);
+
+    const size_t begin = output.num_frames() / 4;
+    const size_t end = 3 * output.num_frames() / 4;
+    double sum_squares = 0.0;
+    for (size_t i = begin; i < end; ++i) {
+      sum_squares += static_cast<double>(output[0][i]) * output[0][i];
+    }
+    const double amplitude =
+        std::sqrt(2.0 * sum_squares / static_cast<double>(end - begin));
+    // 0.02 is roughly -34 dB.
+    EXPECT_LT(amplitude, 0.02) << "aliasing for " << tone_frequency
+                               << " Hz tone, " << source_rate << " -> "
+                               << destination_rate;
+  }
+}
+
 TEST(ResamplerTest, ResetStateTest) {
   // Create input buffer with 1000Hz sine wave at 44100Hz, 441 samples long.
   // This should be ten periods of a sine wave.

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
@@ -126,7 +126,7 @@ TEST(ResamplerTest, DownSampleTest) {
 TEST(ResamplerTest, PassbandGainIsUnityAcrossRatePairs) {
   const std::pair<int, int> kRatePairs[] = {
       {44100, 48000},  {48000, 44100},  {88200, 48000}, {96000, 48000},
-      {176400, 48000}, {192000, 48000}, {48000, 96000}};
+      {176400, 48000}, {192000, 48000}, {48000, 96000}, {48000, 32000}};
   for (const auto& rates : kRatePairs) {
     const int source_rate = rates.first;
     const int destination_rate = rates.second;
@@ -166,9 +166,12 @@ TEST(ResamplerTest, PassbandGainIsUnityAcrossRatePairs) {
 // not folded back into the output band.
 TEST(ResamplerTest, DownsamplingAttenuatesAboveDestinationNyquist) {
   // {source_rate, destination_rate, tone_frequency}; each tone sits at 1.5x
-  // the destination Nyquist frequency.
-  const int kCases[][3] = {
-      {96000, 48000, 36000}, {192000, 48000, 72000}, {88200, 44100, 33000}};
+  // the destination Nyquist frequency. The 88.2k->48k pair covers a
+  // non-integer downsampling factor (1.8375).
+  const int kCases[][3] = {{96000, 48000, 36000},
+                           {192000, 48000, 72000},
+                           {88200, 44100, 33000},
+                           {88200, 48000, 36000}};
   for (const auto& test_case : kCases) {
     const int source_rate = test_case[0];
     const int destination_rate = test_case[1];

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/resampler_test.cc
@@ -12,12 +12,14 @@
 
 #include "obr/ambisonic_binaural_decoder/resampler.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
 #include <numeric>
 #include <utility>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "obr/audio_buffer/audio_buffer.h"
@@ -196,6 +198,67 @@ TEST(ResamplerTest, DownsamplingAttenuatesAboveDestinationNyquist) {
     EXPECT_LT(amplitude, 0.02) << "aliasing for " << tone_frequency
                                << " Hz tone, " << source_rate << " -> "
                                << destination_rate;
+  }
+}
+
+// The partition fix changed coeffs_per_phase_, which determines the size of
+// the streaming state_ buffer carried between Process() calls. Feeding the
+// signal in blocks (including blocks shorter than the state buffer) must
+// produce exactly the same samples as processing it in one shot.
+TEST(ResamplerTest, ChunkedProcessingMatchesOneShot) {
+  const struct {
+    int source_rate;
+    int destination_rate;
+    size_t chunk_size;
+  } kCases[] = {{96000, 48000, 16},  // Chunk shorter than the state buffer.
+                {48000, 96000, 8},   // Ditto, upsampling.
+                {192000, 48000, 160},
+                {44100, 48000, 63},
+                {48000, 44100, 441},
+                {48000, 96000, 100}};
+  for (const auto& test_case : kCases) {
+    const size_t input_length = 4410;
+    AudioBuffer input(kNumMonoChannels, input_length);
+    GenerateSineWave(kToneFrequency, test_case.source_rate, &input[0]);
+
+    Resampler one_shot;
+    one_shot.SetRateAndNumChannels(test_case.source_rate,
+                                   test_case.destination_rate,
+                                   kNumMonoChannels);
+    AudioBuffer one_shot_output(kNumMonoChannels,
+                                one_shot.GetNextOutputLength(input_length));
+    one_shot.Process(input, &one_shot_output);
+
+    Resampler chunked;
+    chunked.SetRateAndNumChannels(test_case.source_rate,
+                                  test_case.destination_rate,
+                                  kNumMonoChannels);
+    std::vector<float> chunked_output;
+    size_t offset = 0;
+    while (offset < input_length) {
+      const size_t this_chunk =
+          std::min(test_case.chunk_size, input_length - offset);
+      AudioBuffer chunk(kNumMonoChannels, this_chunk);
+      std::copy_n(input[0].begin() + offset, this_chunk, chunk[0].begin());
+      AudioBuffer chunk_output(kNumMonoChannels,
+                               chunked.GetNextOutputLength(this_chunk));
+      chunked.Process(chunk, &chunk_output);
+      for (size_t i = 0; i < chunk_output.num_frames(); ++i) {
+        chunked_output.push_back(chunk_output[0][i]);
+      }
+      offset += this_chunk;
+    }
+
+    ASSERT_EQ(one_shot_output.num_frames(), chunked_output.size())
+        << "for " << test_case.source_rate << " -> "
+        << test_case.destination_rate << ", chunk size "
+        << test_case.chunk_size;
+    for (size_t i = 0; i < chunked_output.size(); ++i) {
+      EXPECT_NEAR(one_shot_output[0][i], chunked_output[i], kEpsilonFloat)
+          << "at sample " << i << " for " << test_case.source_rate << " -> "
+          << test_case.destination_rate << ", chunk size "
+          << test_case.chunk_size;
+    }
   }
 }
 

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/sh_hrir_creator_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/tests/sh_hrir_creator_test.cc
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#include "obr/ambisonic_binaural_decoder/sh_hrir_creator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "obr/ambisonic_binaural_decoder/resampler.h"
+#include "obr/audio_buffer/audio_buffer.h"
+
+namespace obr {
+
+namespace {
+
+// The bundled HRIR assets are recorded at this rate; loading at it performs
+// no resampling, which makes it the reference for the invariance tests.
+const int kHrirNativeRateHz = 48000;
+
+// Magnitude of the filter's frequency response (DTFT) at `frequency_hz`.
+double FilterMagnitudeAt(const AudioBuffer& filter, size_t channel,
+                         double frequency_hz, int sample_rate_hz) {
+  std::complex<double> response(0.0, 0.0);
+  for (size_t n = 0; n < filter.num_frames(); ++n) {
+    const double phase = -2.0 * M_PI * frequency_hz * static_cast<double>(n) /
+                         static_cast<double>(sample_rate_hz);
+    response += static_cast<double>(filter[channel][n]) *
+                std::complex<double>(std::cos(phase), std::sin(phase));
+  }
+  return std::abs(response);
+}
+
+// L2 norm of the frequency response magnitudes across all channels. Per-
+// channel magnitudes can be cancellation-dominated (and thus noise-limited)
+// at frequencies where that channel has a null; the cross-channel norm is
+// always well-conditioned and still scales linearly with any gain error.
+double FilterMagnitudeNormAt(const AudioBuffer& filter, double frequency_hz,
+                             int sample_rate_hz) {
+  double sum_squares = 0.0;
+  for (size_t channel = 0; channel < filter.num_channels(); ++channel) {
+    const double magnitude =
+        FilterMagnitudeAt(filter, channel, frequency_hz, sample_rate_hz);
+    sum_squares += magnitude * magnitude;
+  }
+  return std::sqrt(sum_squares);
+}
+
+std::unique_ptr<AudioBuffer> LoadHrirs(const std::string& asset_name,
+                                       int target_sample_rate_hz) {
+  Resampler resampler;
+  return CreateShHrirsFromAssets(asset_name, target_sample_rate_hz,
+                                 &resampler);
+}
+
+// Regression test for rate-dependent binaural loudness: resampling an impulse
+// response with a (waveform-preserving) signal resampler scales the gain of
+// the filter it realizes by target_rate/native_rate unless compensated -
+// +6 dB at 96 kHz with the 48 kHz-native assets. The realized frequency
+// response must be invariant to the target rate at every physical frequency.
+TEST(ShHrirCreatorTest, FilterResponseIsInvariantToTargetRate) {
+  const auto reference = LoadHrirs("3OAAmbientL", kHrirNativeRateHz);
+
+  const int kTargetRates[] = {44100, 88200, 96000};
+  const double kProbeFrequenciesHz[] = {500.0, 1000.0, 2000.0, 4000.0, 8000.0};
+
+  for (const int target_rate : kTargetRates) {
+    const auto resampled = LoadHrirs("3OAAmbientL", target_rate);
+    ASSERT_EQ(reference->num_channels(), resampled->num_channels());
+    for (const double frequency_hz : kProbeFrequenciesHz) {
+      const double reference_norm =
+          FilterMagnitudeNormAt(*reference, frequency_hz, kHrirNativeRateHz);
+      const double resampled_norm =
+          FilterMagnitudeNormAt(*resampled, frequency_hz, target_rate);
+      ASSERT_GT(reference_norm, 0.0);
+      // 0.02 is roughly 0.17 dB, far below the uncompensated errors
+      // (+6 dB at 96k) while leaving room for resampling filter ripple.
+      EXPECT_NEAR(1.0, resampled_norm / reference_norm, 0.02)
+          << frequency_hz << " Hz, target " << target_rate << " Hz";
+    }
+  }
+}
+
+// The compensation must apply uniformly to every channel and every bundled
+// asset variant (ambisonic order, filter profile, ear).
+TEST(ShHrirCreatorTest, FilterResponseIsInvariantPerChannelAcrossAssets) {
+  const std::string kAssets[] = {"1OADirectL", "1OAReverberantR", "2OAAmbientR",
+                                 "3OADirectR"};
+  const int kTargetRate = 96000;
+  const double kProbeFrequencyHz = 1000.0;
+
+  for (const std::string& asset : kAssets) {
+    const auto reference = LoadHrirs(asset, kHrirNativeRateHz);
+    const auto resampled = LoadHrirs(asset, kTargetRate);
+    ASSERT_EQ(reference->num_channels(), resampled->num_channels());
+
+    double max_magnitude = 0.0;
+    for (size_t channel = 0; channel < reference->num_channels(); ++channel) {
+      max_magnitude = std::max(
+          max_magnitude, FilterMagnitudeAt(*reference, channel,
+                                           kProbeFrequencyHz,
+                                           kHrirNativeRateHz));
+    }
+    ASSERT_GT(max_magnitude, 0.0);
+
+    for (size_t channel = 0; channel < reference->num_channels(); ++channel) {
+      const double reference_magnitude = FilterMagnitudeAt(
+          *reference, channel, kProbeFrequencyHz, kHrirNativeRateHz);
+      // Channels with a null at the probe frequency are noise-limited:
+      // their DTFT is a residue of cancelling terms, so the ratio is
+      // meaningless. The cross-channel norm test above covers overall gain.
+      if (reference_magnitude < 0.02 * max_magnitude) {
+        continue;
+      }
+      const double resampled_magnitude =
+          FilterMagnitudeAt(*resampled, channel, kProbeFrequencyHz,
+                            kTargetRate);
+      EXPECT_NEAR(1.0, resampled_magnitude / reference_magnitude, 0.03)
+          << asset << ", channel " << channel;
+    }
+  }
+}
+
+// Loading at the assets' native rate must not resample (or rescale) at all.
+TEST(ShHrirCreatorTest, NativeRateLoadIsUnmodified) {
+  const auto first = LoadHrirs("3OAAmbientL", kHrirNativeRateHz);
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(16U, first->num_channels());
+  EXPECT_GT(first->num_frames(), 0U);
+
+  // A second load must be bit-identical (no hidden resampler state involved).
+  const auto second = LoadHrirs("3OAAmbientL", kHrirNativeRateHz);
+  ASSERT_EQ(first->num_frames(), second->num_frames());
+  for (size_t channel = 0; channel < first->num_channels(); ++channel) {
+    for (size_t n = 0; n < first->num_frames(); ++n) {
+      ASSERT_EQ((*first)[channel][n], (*second)[channel][n]);
+    }
+  }
+}
+
+// The resampled impulse responses must cover the same time span: the tap
+// count scales with the rate ratio.
+TEST(ShHrirCreatorTest, ResampledLengthMatchesRateRatio) {
+  const auto reference = LoadHrirs("3OAAmbientL", kHrirNativeRateHz);
+  const int kTargetRates[] = {44100, 88200, 96000};
+  for (const int target_rate : kTargetRates) {
+    const auto resampled = LoadHrirs("3OAAmbientL", target_rate);
+    const double expected_frames = static_cast<double>(target_rate) /
+                                   static_cast<double>(kHrirNativeRateHz) *
+                                   static_cast<double>(reference->num_frames());
+    EXPECT_NEAR(expected_frames, static_cast<double>(resampled->num_frames()),
+                1.0)
+        << "target " << target_rate << " Hz";
+  }
+}
+
+}  // namespace
+
+}  // namespace obr


### PR DESCRIPTION

Three DSP fixes in the vendored OBR subtree (`src/renderer/obr/obr_capi/obr/obr/ambisonic_binaural_decoder/`), each with regression tests. These surface whenever the output sample rate differs from the 48 kHz-native HRIR assets, or when audio is processed in blocks shorter than the resampler's filter state.

## 1. Polyphase partition bug in the resampler (downsampling gain/anti-aliasing errors)

`GenerateInterpolatingFilter` derived `coeffs_per_phase_` from `max(up_rate_, down_rate_)`, but the polyphase decomposition built by `ArrangeFilterAsPolyphase` has `up_rate_` branches. Whenever `down_rate_ > up_rate_` (downsampling), the tail of the interpolation filter was silently dropped; for integer ratios the kept segment ends before the sinc main lobe. Measured gain errors: +0.65 dB (88.2k→48k), −2.47 dB (96k→48k), −35.1 dB (192k→48k), −41.0 dB (176.4k→48k), with correspondingly degraded anti-aliasing (THD+N as poor as −5 dB at 176.4k→48k). The common 44.1k↔48k pair only loses near-zero window-tail taps, which is why this went unnoticed. Upsampling was unaffected.

Fix: partition the prototype filter across `up_rate_` phases. Note this increases `coeffs_per_phase_` (per-sample cost and state size) for downsampling — the correct cost the truncated filter was not paying.

## 2. State-buffer addressing for input blocks shorter than the filter state

`Process()` carries the last `coeffs_per_phase_ − 1` input samples between calls in `state_`. The branch handling short input buffers addressed the buffer relative to `state_channel.end()`. That was correct in the original Resonance Audio code, where `state_` was allocated at exactly `coeffs_per_phase_ − 1` frames, but this port preallocates `state_` at `kMaxSupportedNumFrames`, so end()-relative writes landed in a dead region while the convolution reads the state from the front. Any block-based use with blocks shorter than the filter state produced corrupted output (near-silence with glitches at block boundaries).

Fix: address the live region relative to `begin()`, matching the read path and the long-input branch.

## 3. HRIR filter gain not compensated for sample-rate conversion

`CreateShHrirsFromWav` resamples the SH HRIRs to the target rate with a waveform-preserving resampler and uses the result directly as convolution filters. Those two operations have different invariants: the gain of the filter realized by discrete convolution is proportional to the rate at which the underlying continuous impulse response is sampled, so the uncompensated result scales the rendered binaural level by `target_rate / native_rate` at every frequency. With the 48 kHz-native bundled assets, rendering at 96 kHz came out +6.02 dB loud and 44.1 kHz −0.73 dB quiet (measured as exactly 2× and exactly 44100/48000 on the DTFT of the loaded filters).

Fix: scale the resampled HRIRs by `wav_rate / target_rate` so rendered loudness is invariant to the output rate.

## Tests

- `resampler_test`: unity passband gain (±0.1 dB) for a 1 kHz tone across seven rate pairs (fails on the old code at e.g. amplitude 0.018 for 192k→48k); anti-aliasing assertion for 96k→48k and 88.2k→44.1k (the tone previously leaked at −11 dB); `ChunkedProcessingMatchesOneShot` verifying block-based processing is sample-exact against one-shot for both directions, including blocks shorter than the filter state.
- New `sh_hrir_creator_test`: cross-channel response-norm invariance over 44.1/88.2/96 kHz at five frequencies, per-channel invariance across asset variants (orders, profiles, both ears), native-rate load determinism, and resampled length vs. rate ratio.
- All pre-existing OBR CMake tests pass.
