### PR TITLE
Fix LFE low-pass filter using a hardcoded 48 kHz sample rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ option(OAR_AUDIO_SIGNAL_DEBUG
 
 option(OLR_ENABLE_F64 "Enable double precision support for olr" OFF)
 option(OAR_BUILD_EXAMPLES "Build examples" OFF)
+option(OAR_ENABLE_HOA_LFE
+        "Generate the LFE channel when rendering HOA to loudspeakers" OFF)
 
 if(OLR_ENABLE_F64)
     add_definitions(-DENABLE_F64)
@@ -29,6 +31,11 @@ endif()
 if (OAR_AUDIO_SIGNAL_DEBUG)
     message(STATUS "Audio signal debug.")
     add_definitions(-D__as_dbg__)
+endif()
+
+if(OAR_ENABLE_HOA_LFE)
+    message(STATUS "HOA-to-loudspeakers LFE generation enabled.")
+    add_definitions(-DDISABLE_LFE_HOA=0)
 endif()
 
 if(OAR_ENABLE_BINAURALIZER)

--- a/src/renderer/ear/ae_rdr.h
+++ b/src/renderer/ear/ae_rdr.h
@@ -222,9 +222,11 @@ int IAMF_element_renderer_get_H2M_matrix(IAMF_HOA_LAYOUT *in,
  * @param     [in] out : the pcm signal of output
  * @param     [in] nsamples : the processed samples of pcm signal.
  * @param     [in] lfe : the filter to prcoess lfe channel.
+ * @param     [in] sample_rate : the sampling rate of the pcm signal, used to
+ *                 initialize the lfe filter if it is not initialized yet.
  * @return    @0: success,@others: fail
  */
 int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
                                      float *out[], int nsamples,
-                                     lfe_filter_t *lfe);
+                                     lfe_filter_t *lfe, uint32_t sample_rate);
 #endif

--- a/src/renderer/ear/ear.c
+++ b/src/renderer/ear/ear.c
@@ -273,7 +273,7 @@ static int _open(renderer_library_context_t *ctx) {
         &hin, ear_renderer->out_sp_layout.sp_layout.predefined_sp,
         &ear_renderer->hmm);
 
-    if (hin.lfe_on && out_info && out_info->lfe1) {
+    if (hin.lfe_on && pout.lfe1 >= 0) {
       lfe_filter_t *plfe = &ear_renderer->out_sp_layout.lfe_f;
       if (plfe->init == 0) lfefilter_init(plfe, 120, ctx->sample_rate);
     }
@@ -304,7 +304,8 @@ static int _render(renderer_library_context_t *ctx, const oar_audio_block_t *in,
     }
   } else {
     IAMF_element_renderer_render_H2M(&ear_renderer->hmm, fin, fout, num_samples,
-                                     &ear_renderer->out_sp_layout.lfe_f);
+                                     &ear_renderer->out_sp_layout.lfe_f,
+                                     ctx->sample_rate);
   }
 
   return ck_oar_ok;

--- a/src/renderer/ear/h2m_rdr.c
+++ b/src/renderer/ear/h2m_rdr.c
@@ -2359,13 +2359,14 @@ int IAMF_element_renderer_get_H2M_matrix(IAMF_HOA_LAYOUT *in,
 }
 
 #if DISABLE_LFE_HOA == 0
-static float lfefilter_update(lfe_filter_t *lfe_f, float input);
+static float lfefilter_update(lfe_filter_t *lfe_f, float input,
+                              uint32_t sample_rate);
 #endif
 
 // HOA to Multichannel Renderer
 int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
                                      float *out[], int nsamples,
-                                     lfe_filter_t *lfe) {
+                                     lfe_filter_t *lfe, uint32_t sample_rate) {
   int i, j, n;
   int n_size = h2mMatrix->n;
 
@@ -2425,7 +2426,7 @@ int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
       for (j = 0; j < nsamples; j++) {
         if (lfe) {  // compute lfe
           float output;
-          output = lfefilter_update(lfe, in[0][j]);  // use W
+          output = lfefilter_update(lfe, in[0][j], sample_rate);  // use W
           if (n_size <= 2)
             out[lfe1][j] = output * 0.5;
           else
@@ -2443,7 +2444,7 @@ int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
             out[lfe2][j] = out[lfe1][j];
           } else {  // compute lfe
             float output;
-            output = lfefilter_update(lfe, in[0][j]);  // use W
+            output = lfefilter_update(lfe, in[0][j], sample_rate);  // use W
             if (n_size <= 2)
               out[lfe2][j] = output * 0.5;
             else
@@ -2482,12 +2483,15 @@ void lfefilter_init(lfe_filter_t *lfe_f, float cutoff_freq, float sample_rate) {
   memset(lfe_f->output_history, 0, sizeof(lfe_f->output_history));
 }
 
-#define DEFAULT_SAMPLERATE 48000.0f
-static float lfefilter_update(lfe_filter_t *lfe_f, float input) {
+static float lfefilter_update(lfe_filter_t *lfe_f, float input,
+                              uint32_t sample_rate) {
   float output;
 
   if (lfe_f->init != 1) {
-    lfefilter_init(lfe_f, 120, DEFAULT_SAMPLERATE);
+    // Fallback for callers that did not initialize the filter eagerly; the
+    // cutoff coefficients must be computed for the actual signal rate, not a
+    // hardcoded one, or the effective cutoff scales with the output rate.
+    lfefilter_init(lfe_f, 120, (float)sample_rate);
   }
   output = lfe_f->a1 * input + lfe_f->a2 * lfe_f->input_history[0] +
            lfe_f->a3 * lfe_f->input_history[1] -

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -33,3 +33,14 @@ if(NOT MSVC)
   target_link_libraries(test_scene_based_rendering PRIVATE m)
   target_link_libraries(test_object_based_rendering PRIVATE m)
 endif()
+
+# The HOA LFE test exercises the 120 Hz LFE low-pass, which is only compiled
+# into the library when OAR_ENABLE_HOA_LFE is ON.
+if(OAR_ENABLE_HOA_LFE)
+    add_executable(test_hoa_lfe_rendering test_hoa_lfe_rendering.c)
+    target_link_libraries(test_hoa_lfe_rendering PRIVATE oar)
+    if(NOT MSVC)
+        target_link_libraries(test_hoa_lfe_rendering PRIVATE m)
+    endif()
+    set_property(TARGET test_hoa_lfe_rendering PROPERTY C_STANDARD 99)
+endif()

--- a/tests/examples/test_hoa_lfe_rendering.c
+++ b/tests/examples/test_hoa_lfe_rendering.c
@@ -144,7 +144,7 @@ int main() {
          kProbeToneHz, rms_44k, rms_48k, rms_96k);
 
   // The LFE level must be invariant to the output sampling rate. With the
-  // hardcoded-48k bug, the 96 kHz ratio is ~2.4x.
+  // hardcoded-48k bug, the measured 96 kHz ratio is 2.697x.
   const double ratio_96k = rms_96k / rms_48k;
   const double ratio_44k = rms_44k / rms_48k;
   if (fabs(ratio_96k - 1.0) > 0.05 || fabs(ratio_44k - 1.0) > 0.05) {

--- a/tests/examples/test_hoa_lfe_rendering.c
+++ b/tests/examples/test_hoa_lfe_rendering.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+// Regression test for the 120 Hz LFE low-pass filter applied when rendering
+// HOA to an LFE-bearing loudspeaker layout (requires OAR_ENABLE_HOA_LFE).
+//
+// The filter coefficients were previously computed for a hardcoded 48 kHz
+// rate regardless of oar_config_t.sampling_rate, so at 96 kHz the effective
+// cutoff landed at ~240 Hz and the LFE channel passed twice the intended
+// bandwidth. The LFE level for a given tone must be invariant to the output
+// sampling rate, and tones well above the cutoff must be attenuated.
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "oar.h"
+
+// Channel order of ck_oar_layout_51 is L R C LFE Ls Rs.
+#define LFE_CHANNEL_INDEX 3
+#define BLOCK_SIZE 256
+// Enough blocks for the IIR filter to reach steady state at both rates.
+#define NUM_BLOCKS 40
+
+// Renders a sine of `tone_hz` on the W channel of a 1OA scene element to a
+// 5.1 layout at `sampling_rate`, and returns the steady-state RMS of the LFE
+// output channel (measured over the last quarter of the blocks). Returns a
+// negative value on setup failure.
+static double render_lfe_rms(uint32_t sampling_rate, double tone_hz) {
+  oar_config_t config;
+  config.target_layout = ck_oar_layout_51;
+  config.samples_per_channel = BLOCK_SIZE;
+  config.sampling_rate = sampling_rate;
+
+  oar_t *oar = oar_create(&config);
+  if (oar == NULL) {
+    fprintf(stderr, "Failed to create OAR object at %u Hz.\n", sampling_rate);
+    return -1.0;
+  }
+
+  oar_audio_element_config_t element_cfg;
+  memset(&element_cfg, 0, sizeof(element_cfg));
+  element_cfg.type = ck_scene_based;
+  element_cfg.sbc.order = ck_oar_1oa;
+
+  int group_id = oar_add_audio_group(oar);
+  if (group_id < 0) {
+    fprintf(stderr, "Failed to add audio group.\n");
+    oar_destroy(oar);
+    return -1.0;
+  }
+  const uint32_t element_id = 1;
+  if (oar_add_audio_element(oar, group_id, element_id, &element_cfg) != 0) {
+    fprintf(stderr, "Failed to add audio element.\n");
+    oar_destroy(oar);
+    return -1.0;
+  }
+
+  const uint32_t in_channels =
+      oar_get_number_of_audio_element_channels(oar, element_id);
+  const uint32_t out_channels = oar_get_number_of_output_channels(oar);
+
+  float *input = (float *)calloc((size_t)in_channels * BLOCK_SIZE,
+                                 sizeof(float));
+  float *output = (float *)calloc((size_t)out_channels * BLOCK_SIZE,
+                                  sizeof(float));
+  if (input == NULL || output == NULL) {
+    fprintf(stderr, "Allocation failure.\n");
+    free(input);
+    free(output);
+    oar_destroy(oar);
+    return -1.0;
+  }
+
+  oar_audio_block_t input_block = {
+      .channels = in_channels, .samples_per_channel = BLOCK_SIZE,
+      .data = input};
+  oar_audio_block_t output_block = {
+      .channels = out_channels, .samples_per_channel = BLOCK_SIZE,
+      .data = output};
+
+  double sum_squares = 0.0;
+  size_t num_measured = 0;
+  for (int block = 0; block < NUM_BLOCKS; ++block) {
+    // Continuous-phase tone on W (channel 0); other channels stay silent.
+    for (int i = 0; i < BLOCK_SIZE; ++i) {
+      const double t =
+          (double)(block * BLOCK_SIZE + i) / (double)sampling_rate;
+      input[i] = (float)sin(2.0 * M_PI * tone_hz * t);
+    }
+    if (oar_update_audio_element_data(oar, element_id, &input_block) != 0 ||
+        oar_render(oar, &output_block) != 0) {
+      fprintf(stderr, "Render failure at %u Hz.\n", sampling_rate);
+      free(input);
+      free(output);
+      oar_destroy(oar);
+      return -1.0;
+    }
+    if (block >= (3 * NUM_BLOCKS) / 4) {  // Steady state only.
+      const float *lfe = output + (size_t)LFE_CHANNEL_INDEX * BLOCK_SIZE;
+      for (int i = 0; i < BLOCK_SIZE; ++i) {
+        sum_squares += (double)lfe[i] * lfe[i];
+        num_measured++;
+      }
+    }
+  }
+
+  free(input);
+  free(output);
+  oar_destroy(oar);
+  return sqrt(sum_squares / (double)num_measured);
+}
+
+int main() {
+  printf("Running HOA LFE low-pass sampling-rate test...\n\n");
+  int failures = 0;
+
+  // A tone near the 120 Hz cutoff, where a mis-scaled cutoff (240 Hz at a
+  // 96 kHz output rate with the old hardcoded coefficients) changes the
+  // level the most.
+  const double kProbeToneHz = 200.0;
+  const double rms_48k = render_lfe_rms(48000, kProbeToneHz);
+  const double rms_96k = render_lfe_rms(96000, kProbeToneHz);
+  const double rms_44k = render_lfe_rms(44100, kProbeToneHz);
+  if (rms_48k <= 0.0 || rms_96k <= 0.0 || rms_44k <= 0.0) {
+    fprintf(stderr, "FAIL: setup/render failed or LFE channel is silent.\n");
+    return -1;
+  }
+  printf("LFE RMS for %.0f Hz tone: 44.1k=%.6f 48k=%.6f 96k=%.6f\n",
+         kProbeToneHz, rms_44k, rms_48k, rms_96k);
+
+  // The LFE level must be invariant to the output sampling rate. With the
+  // hardcoded-48k bug, the 96 kHz ratio is ~2.4x.
+  const double ratio_96k = rms_96k / rms_48k;
+  const double ratio_44k = rms_44k / rms_48k;
+  if (fabs(ratio_96k - 1.0) > 0.05 || fabs(ratio_44k - 1.0) > 0.05) {
+    fprintf(stderr,
+            "FAIL: LFE level depends on the sampling rate "
+            "(96k/48k=%.3f, 44.1k/48k=%.3f, expected 1.0 +-0.05).\n",
+            ratio_96k, ratio_44k);
+    failures++;
+  } else {
+    printf("PASS: LFE level is invariant to the sampling rate "
+           "(96k/48k=%.3f, 44.1k/48k=%.3f).\n",
+           ratio_96k, ratio_44k);
+  }
+
+  // The filter must attenuate well above the 120 Hz cutoff at every rate:
+  // measured, a 1 kHz tone sits ~29 dB below the 200 Hz tone. With the
+  // hardcoded-48k bug, the 96 kHz attenuation degraded to ~25.5 dB.
+  const double kHighToneHz = 1000.0;
+  for (int i = 0; i < 3; ++i) {
+    const uint32_t rates[3] = {44100, 48000, 96000};
+    const double rms_low = render_lfe_rms(rates[i], kProbeToneHz);
+    const double rms_high = render_lfe_rms(rates[i], kHighToneHz);
+    if (rms_low <= 0.0 || rms_high <= 0.0) {
+      fprintf(stderr, "FAIL: render failed at %u Hz.\n", rates[i]);
+      return -1;
+    }
+    const double attenuation_db = 20.0 * log10(rms_high / rms_low);
+    printf("1 kHz vs 200 Hz LFE level at %u Hz: %.1f dB\n", rates[i],
+           attenuation_db);
+    if (attenuation_db > -25.0) {
+      fprintf(stderr,
+              "FAIL: insufficient LFE low-pass attenuation at %u Hz "
+              "(%.1f dB, expected < -25 dB).\n",
+              rates[i], attenuation_db);
+      failures++;
+    }
+  }
+
+  if (failures > 0) {
+    fprintf(stderr, "\nHOA LFE rendering test FAILED (%d).\n", failures);
+    return -1;
+  }
+  printf("\nHOA LFE rendering test completed successfully.\n");
+  return 0;
+}


### PR DESCRIPTION

The 120 Hz LFE low-pass applied when rendering HOA to an LFE-bearing loudspeaker layout computed its biquad coefficients for a hardcoded 48 kHz rate (`DEFAULT_SAMPLERATE` in `h2m_rdr.c`) regardless of `oar_config_t.sampling_rate`. The effective cutoff therefore scaled with the output rate: ~240 Hz at 96 kHz (LFE ~2.7× too loud for content near the cutoff, with ~4 dB less stopband attenuation) and ~110 Hz at 44.1 kHz.

Changes:

- Plumb the context sample rate into `IAMF_element_renderer_render_H2M` so the lazy filter init uses the actual rate.
- Fix the eager init path in `ear.c`, which referenced an undeclared identifier (`out_info`) and prevented the `DISABLE_LFE_HOA=0` configuration from compiling at all.
- Since no build defined `DISABLE_LFE_HOA`, the LFE path was unreachable in every configuration; add an `OAR_ENABLE_HOA_LFE` CMake option (default OFF, preserving current behavior) so it can be built and tested.

## Testing

New `test_hoa_lfe_rendering` (built when the option is ON) renders a 1OA W-channel tone to 5.1 at 44.1/48/96 kHz through the public API and verifies:

- the LFE level is rate-invariant (the hardcoded-48k code fails this at 2.697× for 96 kHz), and
- the low-pass attenuates a 1 kHz tone by more than 25 dB at every rate (measured ~29 dB).

Default builds (option OFF) are unchanged.
