### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a problem with the library
+labels: bug
+---
+
+### Version / commit
+
+`git describe` or `git log -1` can produce this info.
+
+### Environment
+
+OS, compiler, and build options if relevant.
+
+### Steps to reproduce
+
+1.
+2.
+
+### Expected behavior
+
+### Actual behavior
+
+### Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+### Describe the requested feature
+
+### Additional context


### PR DESCRIPTION
Adds Markdown issue templates for bug reports and feature requests.

- The bug report template asks for the version/commit, environment (OS, compiler, build options), reproduction steps, and expected vs. actual behavior.
- Both templates auto-apply a triage label (`bug` / `enhancement`).