### PR TITLE
Apply pre-render object positions and head rotation from the first frame

### DIFF
--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/ambisonic_encoder.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/ambisonic_encoder.cc
@@ -77,6 +77,15 @@ void AmbisonicEncoder::SetSource(size_t input_channel, float gain,
   source_properties.target.elevation = elevation;
   source_properties.target.distance = distance;
 
+  // Before any audio has been rendered there is no previously audible
+  // position to ramp from, so snap to the new parameters. This makes
+  // metadata applied before the first processed block take effect
+  // immediately (matching loudspeaker rendering) instead of gliding in
+  // from the initial position over the first block.
+  if (!has_processed_) {
+    source_properties.current = source_properties.target;
+  }
+
   // If target gain indicates silence, mute the static encoding matrix column
   // as a quick early-out for any code that may still use it.
   if (gain < kNegative120dbInAmplitude) {
@@ -304,6 +313,10 @@ void AmbisonicEncoder::ProcessPlanarAudioData(const AudioBuffer& input_buffer,
   // Update the stored encoding matrix to the last frame's matrix so code that
   // expects a static encoding matrix still has a reasonable value.
   encoding_matrix_ = last_encoding;
+
+  // Audio has now been rendered; subsequent `SetSource()` updates ramp from
+  // the previously audible parameters.
+  has_processed_ = true;
 }
 
 void AmbisonicEncoder::GetShCoeffs(float azimuth, float elevation,

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/ambisonic_encoder.h
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/ambisonic_encoder.h
@@ -129,6 +129,12 @@ class AmbisonicEncoder {
   // Map of structs containing the properties of each source.
   absl::flat_hash_map<size_t, SourceProperties> sources_;
 
+  // False until the first call to `ProcessPlanarAudioData()`. While false,
+  // `SetSource()` snaps `current` to `target` instead of scheduling a ramp:
+  // no audio has been rendered yet, so there is no previously audible
+  // position to interpolate from.
+  bool has_processed_ = false;
+
   AssociatedLegendrePolynomialsGenerator alp_generator_;
   Eigen::MatrixXf encoding_matrix_;
 };

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/tests/ambisonic_encoder_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_encoder/tests/ambisonic_encoder_test.cc
@@ -99,5 +99,83 @@ TEST(AmbisonicEncoderTest, TestOneSampleBufferOneSource) {
   }
 }
 
+// A source position set after the source was created but before any audio
+// has been processed must take effect from the very first frame, with no
+// ramp from the previously set (e.g. default) position.
+TEST(AmbisonicEncoderTest, PreRenderPositionUpdateTakesEffectImmediately) {
+  const size_t buffer_size = 64;
+  const int number_of_input_channels = 1;
+  const int ambisonic_order = 1;
+
+  const float kEpsilon = 1e-6;
+
+  AmbisonicEncoder encoder(number_of_input_channels, ambisonic_order);
+
+  // Source is first registered at the default front position, then moved to
+  // hard left before any processing (mirrors an element being added and its
+  // metadata updated before the first render call).
+  encoder.SetSource(0, 1.0f, 0.0f, 0.0f, 1.0f);
+  encoder.SetSource(0, 1.0f, 90.0f, 0.0f, 1.0f);
+
+  AudioBuffer input_buffer(number_of_input_channels, buffer_size);
+  for (float& sample : input_buffer[0]) {
+    sample = 1.0f;
+  }
+
+  AudioBuffer output_buffer(GetNumPeriphonicComponents(ambisonic_order),
+                            buffer_size);
+  encoder.ProcessPlanarAudioData(input_buffer, &output_buffer);
+
+  // First-order ACN/SN3D coefficients for azimuth 90, elevation 0:
+  // ACN0 = 1, ACN1 = 1, ACN2 = 0, ACN3 = 0. Every frame of the block,
+  // including the first, must carry these coefficients.
+  const std::vector<float> expected_coefficients = {1.0f, 1.0f, 0.0f, 0.0f};
+  for (auto ch = 0; ch < output_buffer.num_channels(); ch++) {
+    for (float sample : output_buffer[ch]) {
+      EXPECT_NEAR(sample, expected_coefficients[ch], kEpsilon);
+    }
+  }
+}
+
+// Once audio has been processed, position updates must still ramp across the
+// next block to avoid clicks: the block starts at the previously audible
+// position and ends at the new one.
+TEST(AmbisonicEncoderTest, PostRenderPositionUpdateRampsAcrossBlock) {
+  const size_t buffer_size = 64;
+  const int number_of_input_channels = 1;
+  const int ambisonic_order = 1;
+
+  const float kEpsilon = 1e-6;
+
+  AmbisonicEncoder encoder(number_of_input_channels, ambisonic_order);
+  encoder.SetSource(0, 1.0f, 0.0f, 0.0f, 1.0f);
+
+  AudioBuffer input_buffer(number_of_input_channels, buffer_size);
+  for (float& sample : input_buffer[0]) {
+    sample = 1.0f;
+  }
+
+  AudioBuffer output_buffer(GetNumPeriphonicComponents(ambisonic_order),
+                            buffer_size);
+
+  // First block renders the source at the front.
+  encoder.ProcessPlanarAudioData(input_buffer, &output_buffer);
+
+  // Move the source to hard left and render another block.
+  encoder.SetSource(0, 1.0f, 90.0f, 0.0f, 1.0f);
+  encoder.ProcessPlanarAudioData(input_buffer, &output_buffer);
+
+  // First-order ACN/SN3D coefficients (ACN0..ACN3): front is {1, 0, 0, 1},
+  // hard left is {1, 1, 0, 0}. The block must start at the front and end
+  // hard left.
+  const std::vector<float> front_coefficients = {1.0f, 0.0f, 0.0f, 1.0f};
+  const std::vector<float> left_coefficients = {1.0f, 1.0f, 0.0f, 0.0f};
+  for (auto ch = 0; ch < output_buffer.num_channels(); ch++) {
+    EXPECT_NEAR(output_buffer[ch][0], front_coefficients[ch], kEpsilon);
+    EXPECT_NEAR(output_buffer[ch][buffer_size - 1], left_coefficients[ch],
+                kEpsilon);
+  }
+}
+
 }  // namespace
 }  // namespace obr

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/ambisonic_rotator.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/ambisonic_rotator.cc
@@ -203,6 +203,19 @@ bool AmbisonicRotator::Process(const WorldRotation& target_rotation,
 
   static const WorldRotation kIdentityRotation;
 
+  // Before any audio has been rendered there is no previously audible
+  // rotation to slerp from, so snap to the target: a head pose set ahead of
+  // the first processed block takes effect from the first frame instead of
+  // gliding in from the initial identity rotation.
+  if (!has_processed_) {
+    has_processed_ = true;
+    if (current_rotation_.AngularDifferenceRad(target_rotation) >=
+        kRotationQuantizationRad) {
+      current_rotation_ = target_rotation;
+      UpdateRotationMatrix(current_rotation_);
+    }
+  }
+
   if (current_rotation_.AngularDifferenceRad(kIdentityRotation) <
           kRotationQuantizationRad &&
       target_rotation.AngularDifferenceRad(kIdentityRotation) <

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/ambisonic_rotator.h
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/ambisonic_rotator.h
@@ -44,6 +44,15 @@ class AmbisonicRotator {
   bool Process(const WorldRotation& target_rotation, const AudioBuffer& input,
                AudioBuffer* output);
 
+  /*!\brief Records that a block of audio was rendered without this rotator
+   * (e.g. with head tracking disabled).
+   *
+   * The unrotated scene was audible, so a later rotation change slerps from
+   * `current_rotation_` instead of being snapped as on the first processed
+   * block.
+   */
+  void MarkAudioRendered() { has_processed_ = true; }
+
  private:
   /*!\brief Updates the rotation matrix with using supplied WorldRotation.
    *
@@ -57,6 +66,12 @@ class AmbisonicRotator {
   // Current rotation which is used in the interpolation process in order to
   // compute new rotation matrix. Initialized with an identity rotation.
   WorldRotation current_rotation_;
+
+  // False until the first call to `Process()`. While false, the target
+  // rotation is applied from the first frame instead of slerping from
+  // `current_rotation_`: no audio has been rendered yet, so there is no
+  // previously audible rotation to interpolate from.
+  bool has_processed_ = false;
 
   // Spherical harmonics rotation sub-matrices for each order.
   std::vector<Eigen::MatrixXf> rotation_matrices_;

--- a/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/tests/ambisonic_rotator_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/ambisonic_rotator/tests/ambisonic_rotator_test.cc
@@ -13,6 +13,7 @@
 #include "obr/ambisonic_rotator/ambisonic_rotator.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <tuple>
@@ -207,6 +208,165 @@ INSTANTIATE_TEST_SUITE_P(
     Values(TestParams({1.0f, 0.0f, 0.0f}, kXrotatedSourceAngle),
            TestParams({0.0f, 1.0f, 0.0f}, kYrotatedSourceAngle),
            TestParams({0.0f, 0.0f, 1.0f}, kZrotatedSourceAngle)));
+
+// A rotation set before any audio has been processed must be applied in full
+// from the very first frame, with no slerp from the initial identity rotation.
+TEST_F(AmbisonicRotatorTest, FirstProcessedBlockAppliesTargetRotationInFull) {
+  const size_t kFramesPerBuffer = 2 * kSlerpFrameInterval;
+  const size_t kNumThirdOrderAmbisonicChannels = 16;
+  const std::vector<float> kInputData(kFramesPerBuffer, 1.0f);
+  AudioBuffer input_buffer(1, kFramesPerBuffer);
+  FillAudioBuffer(kInputData, 1, &input_buffer);
+
+  // Soundfield with a source at the initial angle, to be rotated.
+  AmbisonicEncoder source_mono_codec(1, kAmbisonicOrder);
+  source_mono_codec.SetSource(
+      0, 1.0f, kInitialSourceAngle.azimuth() * kDegreesFromRadians,
+      kInitialSourceAngle.elevation() * kDegreesFromRadians, 1.0f);
+  AudioBuffer encoded_buffer(kNumThirdOrderAmbisonicChannels, kFramesPerBuffer);
+  source_mono_codec.ProcessPlanarAudioData(input_buffer, &encoded_buffer);
+
+  // Reference soundfield with the source already at the rotated angle.
+  AmbisonicEncoder reference_mono_codec(1, kAmbisonicOrder);
+  reference_mono_codec.SetSource(
+      0, 1.0f, kZrotatedSourceAngle.azimuth() * kDegreesFromRadians,
+      kZrotatedSourceAngle.elevation() * kDegreesFromRadians, 1.0f);
+  AudioBuffer reference_buffer(kNumThirdOrderAmbisonicChannels,
+                               kFramesPerBuffer);
+  reference_mono_codec.ProcessPlanarAudioData(input_buffer, &reference_buffer);
+
+  const WorldRotation rotation = WorldRotation(AngleAxisf(
+      kAngleDegrees * kRadiansFromDegrees, WorldPosition(0.0f, 0.0f, 1.0f)));
+
+  hoa_rotator_ = std::make_unique<AmbisonicRotator>(kAmbisonicOrder);
+  EXPECT_TRUE(
+      hoa_rotator_->Process(rotation, encoded_buffer, &encoded_buffer));
+
+  // Every frame of the first processed block, including the first slerp
+  // interval, must match the fully rotated reference.
+  for (size_t channel = 0; channel < encoded_buffer.num_channels();
+       ++channel) {
+    for (size_t frame = 0; frame < kFramesPerBuffer; ++frame) {
+      EXPECT_NEAR(encoded_buffer[channel][frame],
+                  reference_buffer[channel][frame], kEpsilonFloat);
+    }
+  }
+}
+
+// If audio has been rendered without the rotator (head tracking disabled),
+// the unrotated scene was audible, so a later rotation must still slerp from
+// identity across the block instead of being applied in full.
+TEST_F(AmbisonicRotatorTest, RotationAfterBypassedBlocksStillSlerps) {
+  const size_t kFramesPerBuffer = 2 * kSlerpFrameInterval;
+  const size_t kNumThirdOrderAmbisonicChannels = 16;
+  const std::vector<float> kInputData(kFramesPerBuffer, 1.0f);
+  AudioBuffer input_buffer(1, kFramesPerBuffer);
+  FillAudioBuffer(kInputData, 1, &input_buffer);
+
+  AmbisonicEncoder source_mono_codec(1, kAmbisonicOrder);
+  source_mono_codec.SetSource(
+      0, 1.0f, kInitialSourceAngle.azimuth() * kDegreesFromRadians,
+      kInitialSourceAngle.elevation() * kDegreesFromRadians, 1.0f);
+  AudioBuffer encoded_buffer(kNumThirdOrderAmbisonicChannels, kFramesPerBuffer);
+  source_mono_codec.ProcessPlanarAudioData(input_buffer, &encoded_buffer);
+
+  // Reference soundfield with the source already at the rotated angle.
+  AmbisonicEncoder reference_mono_codec(1, kAmbisonicOrder);
+  reference_mono_codec.SetSource(
+      0, 1.0f, kZrotatedSourceAngle.azimuth() * kDegreesFromRadians,
+      kZrotatedSourceAngle.elevation() * kDegreesFromRadians, 1.0f);
+  AudioBuffer reference_buffer(kNumThirdOrderAmbisonicChannels,
+                               kFramesPerBuffer);
+  reference_mono_codec.ProcessPlanarAudioData(input_buffer, &reference_buffer);
+
+  const WorldRotation rotation = WorldRotation(AngleAxisf(
+      kAngleDegrees * kRadiansFromDegrees, WorldPosition(0.0f, 0.0f, 1.0f)));
+
+  hoa_rotator_ = std::make_unique<AmbisonicRotator>(kAmbisonicOrder);
+
+  // Blocks were rendered with the rotator bypassed (head tracking disabled).
+  hoa_rotator_->MarkAudioRendered();
+
+  AudioBuffer rotated_buffer(kNumThirdOrderAmbisonicChannels, kFramesPerBuffer);
+  EXPECT_TRUE(
+      hoa_rotator_->Process(rotation, encoded_buffer, &rotated_buffer));
+
+  float max_first_interval_difference = 0.0f;
+  for (size_t channel = 0; channel < rotated_buffer.num_channels();
+       ++channel) {
+    // The last slerp interval has undergone the full rotation.
+    for (size_t frame = kFramesPerBuffer - kSlerpFrameInterval;
+         frame < kFramesPerBuffer; ++frame) {
+      EXPECT_NEAR(rotated_buffer[channel][frame],
+                  reference_buffer[channel][frame], kEpsilonFloat);
+    }
+    // Track how far the first slerp interval is from the full rotation.
+    for (size_t frame = 0; frame < kSlerpFrameInterval; ++frame) {
+      max_first_interval_difference = std::max(
+          max_first_interval_difference,
+          std::abs(rotated_buffer[channel][frame] -
+                   reference_buffer[channel][frame]));
+    }
+  }
+  // The first slerp interval must still be part-way through the rotation.
+  EXPECT_GT(max_first_interval_difference, 0.01f);
+}
+
+// Once audio has been processed, rotation changes must still be smoothed
+// across the next block: the block ends at the new rotation but does not
+// start there.
+TEST_F(AmbisonicRotatorTest, RotationChangeAfterFirstBlockStillSlerps) {
+  const size_t kFramesPerBuffer = 2 * kSlerpFrameInterval;
+  const size_t kNumThirdOrderAmbisonicChannels = 16;
+  const std::vector<float> kInputData(kFramesPerBuffer, 1.0f);
+  AudioBuffer input_buffer(1, kFramesPerBuffer);
+  FillAudioBuffer(kInputData, 1, &input_buffer);
+
+  AmbisonicEncoder source_mono_codec(1, kAmbisonicOrder);
+  source_mono_codec.SetSource(
+      0, 1.0f, kInitialSourceAngle.azimuth() * kDegreesFromRadians,
+      kInitialSourceAngle.elevation() * kDegreesFromRadians, 1.0f);
+  AudioBuffer encoded_buffer(kNumThirdOrderAmbisonicChannels, kFramesPerBuffer);
+  source_mono_codec.ProcessPlanarAudioData(input_buffer, &encoded_buffer);
+
+  const WorldRotation rotation = WorldRotation(AngleAxisf(
+      kAngleDegrees * kRadiansFromDegrees, WorldPosition(0.0f, 0.0f, 1.0f)));
+
+  hoa_rotator_ = std::make_unique<AmbisonicRotator>(kAmbisonicOrder);
+
+  // First block: rotation applied in full (snap).
+  AudioBuffer rotated_buffer(kNumThirdOrderAmbisonicChannels, kFramesPerBuffer);
+  EXPECT_TRUE(
+      hoa_rotator_->Process(rotation, encoded_buffer, &rotated_buffer));
+
+  // Second block: return to identity. The output must end as the unrotated
+  // input (slerp completed) but must not start there (still mid-slerp).
+  AudioBuffer transition_buffer(kNumThirdOrderAmbisonicChannels,
+                                kFramesPerBuffer);
+  EXPECT_TRUE(hoa_rotator_->Process(WorldRotation(), encoded_buffer,
+                                    &transition_buffer));
+
+  float max_first_interval_difference = 0.0f;
+  for (size_t channel = 0; channel < transition_buffer.num_channels();
+       ++channel) {
+    // The last slerp interval has undergone the full rotation back to
+    // identity, so it must match the unrotated input.
+    for (size_t frame = kFramesPerBuffer - kSlerpFrameInterval;
+         frame < kFramesPerBuffer; ++frame) {
+      EXPECT_NEAR(transition_buffer[channel][frame],
+                  encoded_buffer[channel][frame], kEpsilonFloat);
+    }
+    // Track how far the first slerp interval is from the unrotated input.
+    for (size_t frame = 0; frame < kSlerpFrameInterval; ++frame) {
+      max_first_interval_difference = std::max(
+          max_first_interval_difference,
+          std::abs(transition_buffer[channel][frame] -
+                   encoded_buffer[channel][frame]));
+    }
+  }
+  // The first slerp interval must still be part-way through the rotation.
+  EXPECT_GT(max_first_interval_difference, 0.01f);
+}
 
 }  // namespace
 

--- a/src/renderer/obr/obr_capi/obr/obr/renderer/processing_group.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/renderer/processing_group.cc
@@ -182,6 +182,11 @@ void ProcessingGroup::Process(
     // Pass world-locked Ambisonic mix bed through Ambisonic Rotator.
     ambisonic_rotator_->Process(world_rotation, ambisonic_mix_bed_,
                                 &ambisonic_mix_bed_);
+  } else {
+    // The block is rendered unrotated; let the rotator know so a later
+    // rotation change slerps from the audible identity rotation instead of
+    // snapping.
+    ambisonic_rotator_->MarkAudioRendered();
   }
 
   // Sum both beds: combine world-locked (possibly rotated) and head-locked.


### PR DESCRIPTION
Fixes #21.

**Problem**

As analyzed in #21, OLR and OBR disagree on metadata applied before the first render call. When an audio element is added, OBR registers each object source with the ambisonic encoder at the default position (azimuth 0, elevation 0, distance 1). A position update arriving before the first `Process()` call only moves the ramp *target*, so the first rendered block audibly glides the object from front-center to its configured position. OLR applies pre-render metadata immediately, so loudspeaker and binaural output differ over the first block. The same pattern exists in the ambisonic rotator: a head pose set before the first render slerps in from identity.

**Fix**

Until a component has rendered any audio there is no previously audible state to interpolate from, so updates snap instead of scheduling a ramp:

- `AmbisonicEncoder` tracks whether it has processed a block; while it hasn't, `SetSource()` sets `current` along with `target`. This covers every pre-render update path (object channels, loudspeaker-channel positions, gains) since they all funnel through `SetSource()`.
- `AmbisonicRotator` does the same for the target rotation on its first processed block.
- Blocks rendered with head tracking disabled bypass the rotator but are audible at the identity rotation, so `ProcessingGroup` marks them via `MarkAudioRendered()`; enabling head tracking with a stored pose after such blocks still slerps instead of snapping.

Updates arriving after audio has been rendered still ramp/slerp across one block to avoid clicks, and mid-stream update semantics are unchanged.

**Tests**

- `AmbisonicEncoderTest.PreRenderPositionUpdateTakesEffectImmediately` — reproduces the #21 glide on unfixed code (frame 0 carries the front-position coefficients instead of the configured position).
- `AmbisonicEncoderTest.PostRenderPositionUpdateRampsAcrossBlock` — guards the click-avoidance ramp after audio has flowed.
- `AmbisonicRotatorTest.FirstProcessedBlockAppliesTargetRotationInFull`, `RotationAfterBypassedBlocksStillSlerps`, `RotationChangeAfterFirstBlockStillSlerps` — same contract for the rotator, including the head-tracking-disabled case.

Each "first block" test fails without its fix; the existing encoder and rotator tests pass unchanged.
