### PR TITLE
Lock the OBR mutex in head-tracking and limiter setters

### DIFF
--- a/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.cc
@@ -422,14 +422,24 @@ absl::Status ObrImpl::UpdateObjectChannelPosition(size_t audio_element_index,
 }
 
 void ObrImpl::EnableHeadTracking(bool enable_head_tracking) {
+  // Acquire mutex: `head_tracking_enabled_` is read by `Process()` on the
+  // audio thread.
+  absl::MutexLock lock(&mutex_);
   head_tracking_enabled_ = enable_head_tracking;
 }
 
 void ObrImpl::EnableLimiter(bool enable_limiter) {
+  // Acquire mutex: `limiter_enabled_` is read by `Process()` on the audio
+  // thread.
+  absl::MutexLock lock(&mutex_);
   limiter_enabled_ = enable_limiter;
 }
 
 absl::Status ObrImpl::SetHeadRotation(float w, float x, float y, float z) {
+  // Acquire mutex: `world_rotation_` is read by `Process()` on the audio
+  // thread, and head rotation updates typically arrive from a sensor thread.
+  absl::MutexLock lock(&mutex_);
+
   // Apply counter-rotation for head tracking.
   world_rotation_ = WorldRotation(w, -x, -y, -z);
 


### PR DESCRIPTION
`SetHeadRotation()`, `EnableHeadTracking()` and `EnableLimiter()` wrote `world_rotation_`, `head_tracking_enabled_` and `limiter_enabled_` without acquiring `mutex_`, while `Process()` reads all three under the lock for the duration of each rendered block. Head rotation in particular is typically updated from a sensor thread while the audio thread renders, so the unsynchronized 4-float quaternion write could be observed torn mid-block — and all three writes are data races regardless.

Every other `ObrImpl` mutator already takes the mutex; this makes the remaining three do the same. The setters are only called from the C API wrappers (`obr_capi.cpp`), so no caller holds the lock and there is no deadlock path.

No functional change on a single thread; existing tests pass unchanged.
