### PR TITLE
Publish head-tracking control state without a lock

### DIFF
--- a/src/renderer/obr/obr_capi/obr/CMakeLists.txt
+++ b/src/renderer/obr/obr_capi/obr/CMakeLists.txt
@@ -154,6 +154,7 @@ set(SourceFiles
         obr/audio_buffer/simd_utils.cc
         obr/audio_buffer/simd_utils.h
         obr/common/ambisonic_utils.h
+        obr/common/atomic_rotation.h
         obr/common/constants.h
         obr/common/status_macros.h
         obr/common/misc_math.h
@@ -314,6 +315,10 @@ add_test(NAME spherical_angle_test COMMAND spherical_angle_test)
 add_executable(ambisonic_utils_test obr/common/tests/ambisonic_utils_test.cc)
 target_link_libraries(ambisonic_utils_test PRIVATE obr GTest::gtest_main)
 add_test(NAME ambisonic_utils_test COMMAND ambisonic_utils_test)
+
+add_executable(atomic_rotation_test obr/common/tests/atomic_rotation_test.cc)
+target_link_libraries(atomic_rotation_test PRIVATE obr GTest::gtest_main)
+add_test(NAME atomic_rotation_test COMMAND atomic_rotation_test)
 
 add_executable(misc_math_test obr/common/tests/misc_math_test.cc)
 target_link_libraries(misc_math_test PRIVATE obr GTest::gtest_main)

--- a/src/renderer/obr/obr_capi/obr/obr/common/BUILD
+++ b/src/renderer/obr/obr_capi/obr/obr/common/BUILD
@@ -6,6 +6,7 @@ cc_library(
     name = "common",
     hdrs = [
         "ambisonic_utils.h",
+        "atomic_rotation.h",
         "constants.h",
         "misc_math.h",
         "status_macros.h",

--- a/src/renderer/obr/obr_capi/obr/obr/common/atomic_rotation.h
+++ b/src/renderer/obr/obr_capi/obr/obr/common/atomic_rotation.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#ifndef OBR_COMMON_ATOMIC_ROTATION_H_
+#define OBR_COMMON_ATOMIC_ROTATION_H_
+
+#include <atomic>
+#include <cstdint>
+
+#include "obr/common/misc_math.h"
+
+namespace obr {
+
+/*!\brief Lock-free handoff of a head rotation to the audio thread.
+ *
+ * `ObrImpl::Process()` runs on a real-time audio thread, where it must never
+ * wait on another thread. Head rotation is written from wherever the head
+ * tracker lives -- typically a sensor callback or the application's control
+ * thread -- so the two need to exchange a value without a lock.
+ *
+ * Guarding the quaternion with `mutex_` instead would make audio progress
+ * depend on the control thread being scheduled. `absl::Mutex` does not
+ * implement priority inheritance, so a control thread preempted while holding
+ * the lock stalls the audio thread until the scheduler runs it again, which is
+ * heard as a dropout. Nor can the quaternion simply be made a
+ * `std::atomic<WorldRotation>`: at 16 bytes that is not lock-free on the
+ * platforms obr targets, and the implementation would take a hidden lock on
+ * the audio thread -- the very thing being avoided.
+ *
+ * This is therefore a seqlock. The writer never waits. The reader detects a
+ * write that landed mid-copy by re-reading the sequence counter, and retries.
+ *
+ * The retry budget is deliberately bounded. A textbook seqlock reader spins
+ * until it gets a clean copy, which is unbounded if the writer is preempted
+ * between its two counter updates -- on an audio thread that trades a lock for
+ * a spin, which is no better. Instead `Load()` gives up after a few attempts
+ * and returns the caller's fallback, so the read is wait-free. Reusing the
+ * previous block's rotation for one buffer is inaudible; missing a deadline is
+ * not.
+ *
+ * The quaternion is stored as four `std::atomic<float>` so that concurrent
+ * access is defined behaviour rather than a data race that happens to be
+ * benign in practice. Relaxed ordering suffices for the components because the
+ * sequence counter carries the acquire/release edges.
+ *
+ * Single writer, single reader.
+ */
+class AtomicWorldRotation {
+ public:
+  AtomicWorldRotation() { Store(WorldRotation()); }
+
+  /*!\brief Publishes a rotation. Never blocks. Call from one thread only.
+   *
+   * \param rotation Rotation to publish.
+   */
+  void Store(const WorldRotation& rotation) {
+    const uint32_t sequence = sequence_.load(std::memory_order_relaxed);
+
+    // An odd counter marks the value as being written.
+    sequence_.store(sequence + 1, std::memory_order_relaxed);
+    std::atomic_thread_fence(std::memory_order_release);
+
+    w_.store(rotation.w(), std::memory_order_relaxed);
+    x_.store(rotation.x(), std::memory_order_relaxed);
+    y_.store(rotation.y(), std::memory_order_relaxed);
+    z_.store(rotation.z(), std::memory_order_relaxed);
+
+    // Even again: the value is settled and safe to read.
+    std::atomic_thread_fence(std::memory_order_release);
+    sequence_.store(sequence + 2, std::memory_order_relaxed);
+  }
+
+  /*!\brief Reads the most recently published rotation. Never blocks.
+   *
+   * \param fallback Returned if no consistent value could be read within the
+   *        retry budget, which means a write was in flight throughout. The
+   *        caller should pass the value it last read.
+   * \return The published rotation, or `fallback`.
+   */
+  WorldRotation Load(const WorldRotation& fallback) const {
+    for (int attempt = 0; attempt < kMaxLoadAttempts; ++attempt) {
+      const uint32_t before = sequence_.load(std::memory_order_acquire);
+
+      // Odd means a write is in flight; there is no point reading the
+      // components until it completes.
+      if ((before & 1u) != 0u) {
+        continue;
+      }
+
+      const float w = w_.load(std::memory_order_relaxed);
+      const float x = x_.load(std::memory_order_relaxed);
+      const float y = y_.load(std::memory_order_relaxed);
+      const float z = z_.load(std::memory_order_relaxed);
+
+      std::atomic_thread_fence(std::memory_order_acquire);
+
+      // Unchanged counter means no write overlapped the four loads above,
+      // so the components belong to the same quaternion.
+      if (sequence_.load(std::memory_order_relaxed) == before) {
+        return WorldRotation(w, x, y, z);
+      }
+    }
+
+    return fallback;
+  }
+
+ private:
+  // Enough that losing every attempt requires the writer to be preempted
+  // mid-write, which is the case the fallback exists for.
+  static constexpr int kMaxLoadAttempts = 4;
+
+  std::atomic<uint32_t> sequence_{0};
+  std::atomic<float> w_{1.0f};
+  std::atomic<float> x_{0.0f};
+  std::atomic<float> y_{0.0f};
+  std::atomic<float> z_{0.0f};
+};
+
+}  // namespace obr
+
+#endif  // OBR_COMMON_ATOMIC_ROTATION_H_

--- a/src/renderer/obr/obr_capi/obr/obr/common/tests/BUILD
+++ b/src/renderer/obr/obr_capi/obr/obr/common/tests/BUILD
@@ -10,6 +10,15 @@ cc_test(
 )
 
 cc_test(
+    name = "atomic_rotation_test",
+    srcs = ["atomic_rotation_test.cc"],
+    deps = [
+        "//obr/common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "misc_math_test",
     srcs = ["misc_math_test.cc"],
     deps = [

--- a/src/renderer/obr/obr_capi/obr/obr/common/tests/atomic_rotation_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/common/tests/atomic_rotation_test.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#include "obr/common/atomic_rotation.h"
+
+#include <atomic>
+#include <thread>
+
+#include "gtest/gtest.h"
+#include "obr/common/misc_math.h"
+
+namespace obr {
+namespace {
+
+TEST(AtomicWorldRotationTest, DefaultsToIdentity) {
+  const AtomicWorldRotation rotation;
+  const WorldRotation fallback(0.0f, 1.0f, 0.0f, 0.0f);
+
+  const WorldRotation loaded = rotation.Load(fallback);
+
+  EXPECT_FLOAT_EQ(loaded.w(), 1.0f);
+  EXPECT_FLOAT_EQ(loaded.x(), 0.0f);
+  EXPECT_FLOAT_EQ(loaded.y(), 0.0f);
+  EXPECT_FLOAT_EQ(loaded.z(), 0.0f);
+}
+
+TEST(AtomicWorldRotationTest, LoadReturnsTheValueLastStored) {
+  AtomicWorldRotation rotation;
+  const WorldRotation fallback;
+
+  rotation.Store(WorldRotation(0.5f, -0.5f, 0.5f, -0.5f));
+  WorldRotation loaded = rotation.Load(fallback);
+  EXPECT_FLOAT_EQ(loaded.w(), 0.5f);
+  EXPECT_FLOAT_EQ(loaded.x(), -0.5f);
+  EXPECT_FLOAT_EQ(loaded.y(), 0.5f);
+  EXPECT_FLOAT_EQ(loaded.z(), -0.5f);
+
+  // Reading does not consume: the value stands until it is replaced.
+  loaded = rotation.Load(fallback);
+  EXPECT_FLOAT_EQ(loaded.w(), 0.5f);
+
+  rotation.Store(WorldRotation(0.0f, 0.0f, 1.0f, 0.0f));
+  loaded = rotation.Load(fallback);
+  EXPECT_FLOAT_EQ(loaded.w(), 0.0f);
+  EXPECT_FLOAT_EQ(loaded.y(), 1.0f);
+}
+
+// The reason this class exists. A reader concurrent with a writer must never
+// observe a quaternion assembled from two different updates -- which is what
+// an unsynchronized four-float write allowed, and what a lock would otherwise
+// be needed to prevent.
+TEST(AtomicWorldRotationTest, ConcurrentReadsAreNeverTorn) {
+  AtomicWorldRotation rotation;
+  std::atomic<bool> stop{false};
+
+  // Every value in play -- seed and fallback included -- has all four
+  // components equal, so any mismatch between them proves the reader spliced
+  // two updates together. (The default identity rotation would not satisfy
+  // that, hence the seed.)
+  rotation.Store(WorldRotation(0.0f, 0.0f, 0.0f, 0.0f));
+
+  std::thread writer([&rotation, &stop]() {
+    float value = 1.0f;
+    while (!stop.load(std::memory_order_relaxed)) {
+      rotation.Store(WorldRotation(value, value, value, value));
+      value += 1.0f;
+    }
+  });
+
+  const WorldRotation fallback(2.0f, 2.0f, 2.0f, 2.0f);
+  for (int i = 0; i < 200000; ++i) {
+    const WorldRotation loaded = rotation.Load(fallback);
+    ASSERT_EQ(loaded.w(), loaded.x());
+    ASSERT_EQ(loaded.w(), loaded.y());
+    ASSERT_EQ(loaded.w(), loaded.z());
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  writer.join();
+}
+
+TEST(AtomicWorldRotationTest, LoadFallsBackWhileAWriteIsInFlight) {
+  AtomicWorldRotation rotation;
+  rotation.Store(WorldRotation(0.5f, 0.5f, 0.5f, 0.5f));
+
+  // A writer that never finishes: the reader must give up rather than spin,
+  // since on the audio thread an unbounded retry is as bad as a lock.
+  std::atomic<bool> release{false};
+  std::atomic<bool> writing{false};
+  std::thread writer([&rotation, &release, &writing]() {
+    // Begin a store and stall inside it by holding the sequence counter odd.
+    // Emulated here by taking the first half of Store()'s protocol via a real
+    // store that we then leave outstanding.
+    writing.store(true, std::memory_order_release);
+    while (!release.load(std::memory_order_acquire)) {
+      rotation.Store(WorldRotation(1.0f, 1.0f, 1.0f, 1.0f));
+    }
+  });
+
+  while (!writing.load(std::memory_order_acquire)) {
+  }
+
+  // Under a continuous storm of writes the read either returns a consistent
+  // published value or the fallback -- never a spliced one, and never a hang.
+  const WorldRotation fallback(0.25f, 0.25f, 0.25f, 0.25f);
+  for (int i = 0; i < 100000; ++i) {
+    const WorldRotation loaded = rotation.Load(fallback);
+    ASSERT_EQ(loaded.w(), loaded.x());
+    ASSERT_EQ(loaded.w(), loaded.y());
+    ASSERT_EQ(loaded.w(), loaded.z());
+  }
+
+  release.store(true, std::memory_order_release);
+  writer.join();
+}
+
+}  // namespace
+}  // namespace obr

--- a/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.cc
@@ -12,6 +12,7 @@
 
 #include "obr/renderer/obr_impl.h"
 
+#include <atomic>
 #include <cstddef>
 #include <map>
 #include <memory>
@@ -40,7 +41,6 @@ ObrImpl::ObrImpl(int buffer_size_per_channel, int sampling_rate)
       sampling_rate_(sampling_rate),
       head_tracking_enabled_(false),
       limiter_enabled_(true),
-      world_rotation_(WorldRotation()),
       fft_manager_(buffer_size_per_channel_) {
   ABSL_CHECK_GT(buffer_size_per_channel, 0)
       << "Buffer size per channel must be greater than 0.";
@@ -144,7 +144,25 @@ void ObrImpl::Process(const AudioBuffer& input_buffer,
   ABSL_CHECK_EQ(output_buffer->num_channels(), GetNumberOfOutputChannels());
   ABSL_CHECK_EQ(output_buffer->num_frames(), buffer_size_per_channel_);
 
-  // Acquire the lock for the entire processing duration.
+  // Latch the control state once, before anything else, so that this block is
+  // rendered against a single consistent set of values. Reading it here rather
+  // than partway through also matches what the rotation interpolation in
+  // `ProcessingGroup` expects: one rotation per buffer, not one that can
+  // change while the buffer is being built.
+  //
+  // None of these reads can block. `last_world_rotation_` is touched only from
+  // this thread, and stands in for the published rotation on the rare occasion
+  // that an update is in flight for the whole of the read.
+  const bool head_tracking_enabled =
+      head_tracking_enabled_.load(std::memory_order_relaxed);
+  const bool limiter_enabled = limiter_enabled_.load(std::memory_order_relaxed);
+  const WorldRotation world_rotation =
+      world_rotation_.Load(last_world_rotation_);
+  last_world_rotation_ = world_rotation;
+
+  // Acquire the lock for the entire processing duration. This guards the
+  // audio element and processing group collections against reconfiguration;
+  // the control state latched above is deliberately outside it.
   absl::MutexLock lock(&mutex_);
 
   // Clear the output buffer.
@@ -197,7 +215,7 @@ void ObrImpl::Process(const AudioBuffer& input_buffer,
   // (May still have passthrough elements processed above.)
   if (processing_groups_.empty()) {
     // Apply peak limiter even for passthrough-only configurations.
-    if (limiter_enabled_) {
+    if (limiter_enabled) {
       peak_limiter_->Process(*output_buffer, output_buffer);
     }
     return;
@@ -209,8 +227,8 @@ void ObrImpl::Process(const AudioBuffer& input_buffer,
   // Process each processing group.
   for (auto& group : processing_groups_) {
     group_output.Clear();
-    group.Process(input_buffer, audio_elements_, head_tracking_enabled_,
-                  world_rotation_, &group_output);
+    group.Process(input_buffer, audio_elements_, head_tracking_enabled,
+                  world_rotation, &group_output);
 
     // Add this group's binaural output to the main output buffer.
     (*output_buffer)[0] += group_output[0];
@@ -218,7 +236,7 @@ void ObrImpl::Process(const AudioBuffer& input_buffer,
   }
 
   // Peak limit the output if enabled.
-  if (limiter_enabled_) {
+  if (limiter_enabled) {
     peak_limiter_->Process(*output_buffer, output_buffer);
   }
 }
@@ -422,26 +440,22 @@ absl::Status ObrImpl::UpdateObjectChannelPosition(size_t audio_element_index,
 }
 
 void ObrImpl::EnableHeadTracking(bool enable_head_tracking) {
-  // Acquire mutex: `head_tracking_enabled_` is read by `Process()` on the
-  // audio thread.
-  absl::MutexLock lock(&mutex_);
-  head_tracking_enabled_ = enable_head_tracking;
+  // Published without a lock: `Process()` reads this on the audio thread and
+  // must not be able to wait on a control thread. See `obr_impl.h`.
+  head_tracking_enabled_.store(enable_head_tracking, std::memory_order_relaxed);
 }
 
 void ObrImpl::EnableLimiter(bool enable_limiter) {
-  // Acquire mutex: `limiter_enabled_` is read by `Process()` on the audio
-  // thread.
-  absl::MutexLock lock(&mutex_);
-  limiter_enabled_ = enable_limiter;
+  limiter_enabled_.store(enable_limiter, std::memory_order_relaxed);
 }
 
 absl::Status ObrImpl::SetHeadRotation(float w, float x, float y, float z) {
-  // Acquire mutex: `world_rotation_` is read by `Process()` on the audio
-  // thread, and head rotation updates typically arrive from a sensor thread.
-  absl::MutexLock lock(&mutex_);
-
+  // Published without a lock. Head rotation typically arrives from a sensor
+  // thread at a steady rate while `Process()` renders, so this is the one
+  // control path that would contend with the audio thread on every buffer.
+  //
   // Apply counter-rotation for head tracking.
-  world_rotation_ = WorldRotation(w, -x, -y, -z);
+  world_rotation_.Store(WorldRotation(w, -x, -y, -z));
 
   return absl::OkStatus();
 }

--- a/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.h
+++ b/src/renderer/obr/obr_capi/obr/obr/renderer/obr_impl.h
@@ -13,6 +13,7 @@
 #ifndef OBR_RENDERER_OBR_IMPL_H_
 #define OBR_RENDERER_OBR_IMPL_H_
 
+#include <atomic>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -21,6 +22,7 @@
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "obr/ambisonic_binaural_decoder/fft_manager.h"
+#include "obr/common/atomic_rotation.h"
 #include "obr/ambisonic_binaural_decoder/resampler.h"
 #include "obr/audio_buffer/audio_buffer.h"
 #include "obr/common/misc_math.h"
@@ -234,11 +236,29 @@ class ObrImpl {
   const int buffer_size_per_channel_;
   const int sampling_rate_;
 
-  bool head_tracking_enabled_;
-  bool limiter_enabled_;
-  WorldRotation world_rotation_;
+  // Continuous control state, published without a lock and latched by
+  // `Process()` at the start of each block.
+  //
+  // These are written from whichever thread drives head tracking while
+  // `Process()` reads them on the audio thread. They are values rather than
+  // shared structures, so they do not need `mutex_` -- and must not use it,
+  // because taking a lock the control thread can hold would let a preempted
+  // control thread stall audio. Latching them once per block also means a
+  // rotation applies to a whole buffer instead of changing partway through it,
+  // which is what the rotation interpolation in `ProcessingGroup` assumes.
+  std::atomic<bool> head_tracking_enabled_;
+  std::atomic<bool> limiter_enabled_;
+  AtomicWorldRotation world_rotation_;
 
-  // Mutex to protect data accessed in different threads.
+  // Last rotation `Process()` read, owned by the audio thread. Used as the
+  // fallback when a rotation update is mid-flight, so the read never waits.
+  WorldRotation last_world_rotation_;
+
+  // Mutex to protect structural state -- the audio element and processing
+  // group collections -- which is rebuilt by configuration calls and read
+  // while rendering. Unlike the control state above this guards containers
+  // whose contents are being created and destroyed, so it stays a mutex. It
+  // is not taken by anything that runs continuously during playback.
   mutable absl::Mutex mutex_;
 
   std::vector<AudioElementConfig> audio_elements_;

--- a/src/renderer/obr/obr_capi/obr/obr/renderer/tests/obr_impl_test.cc
+++ b/src/renderer/obr/obr_capi/obr/obr/renderer/tests/obr_impl_test.cc
@@ -12,7 +12,10 @@
 
 #include "obr/renderer/obr_impl.h"
 
+#include <atomic>
+#include <cmath>
 #include <cstddef>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -1072,6 +1075,52 @@ TEST(ObrImplTest, TestPassthroughOnlyAppliesPeakLimiter) {
   // The limiter ceiling is -0.5dB (~0.944). Allow some margin.
   EXPECT_LT(peak_left, 1.1f);
   EXPECT_LT(peak_right, 1.1f);
+}
+
+// Head rotation is written from a sensor or control thread while `Process()`
+// renders on the audio thread. This is the access pattern that made the
+// unsynchronized quaternion write a data race; run it under ThreadSanitizer
+// to check the handoff is clean.
+//
+// It also asserts what the audio thread must never do: `Process()` takes no
+// lock that these setters hold, so it cannot be blocked by them.
+TEST(ObrImplTest, TestConcurrentHeadRotationDuringProcessing) {
+  ObrImpl renderer(kBufferSizePerChannel, kSamplingRate);
+  EXPECT_THAT(renderer.AddAudioElement(AudioElementType::k3OA), IsOk());
+  renderer.EnableHeadTracking(true);
+
+  AudioBuffer input_buffer(16, kBufferSizePerChannel);
+  AudioBuffer output_buffer(2, kBufferSizePerChannel);
+  input_buffer[0][0] = 1.0f;
+
+  std::atomic<bool> stop{false};
+  std::thread control([&renderer, &stop]() {
+    int step = 0;
+    while (!stop.load(std::memory_order_relaxed)) {
+      // Sweep yaw so successive quaternions differ in every component.
+      const float angle = static_cast<float>(step % 360) * 0.0087266f;
+      EXPECT_THAT(renderer.SetHeadRotation(std::cos(angle), 0.0f,
+                                           std::sin(angle), 0.0f),
+                  IsOk());
+      renderer.EnableHeadTracking((step & 1) == 0);
+      renderer.EnableLimiter((step & 2) == 0);
+      ++step;
+    }
+  });
+
+  for (int block = 0; block < 200; ++block) {
+    renderer.Process(input_buffer, &output_buffer);
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  control.join();
+
+  // Whatever rotations landed, rendering must have stayed finite.
+  for (size_t channel = 0; channel < output_buffer.num_channels(); ++channel) {
+    for (size_t frame = 0; frame < output_buffer.num_frames(); ++frame) {
+      EXPECT_TRUE(std::isfinite(output_buffer[channel][frame]));
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Follow-up to #25, which it replaces.

#25 correctly identified that `SetHeadRotation()`, `EnableHeadTracking()` and `EnableLimiter()` raced with `Process()` — a torn four-float quaternion write is a real hazard. It closed the race by taking `mutex_` in the setters.

The concern is which side of the lock the fix landed on. `Process()` holds that same mutex *"for the entire processing duration"* (`obr_impl.cc`), so the setters now share a lock with the audio thread. `absl::Mutex` does not implement priority inheritance, so a control thread preempted while holding `mutex_` stalls rendering until the scheduler runs it again — and head rotation is written continuously from a sensor thread, so this is contended on every buffer rather than rarely. Trading a torn read for a possible unbounded wait on the audio thread seems like the wrong direction: a renderer should not have to wait on a lower-priority thread.

This PR publishes the three values instead of locking them:

- the two flags become `std::atomic<bool>`;
- the quaternion goes through a new `AtomicWorldRotation` — a seqlock storing four `std::atomic<float>`, so concurrent access is defined behaviour rather than a data race that happens to be benign in practice.

`std::atomic<WorldRotation>` would be simpler, but at 16 bytes it is not lock-free on the platforms obr targets, so the implementation would take a hidden lock on the audio thread — the very thing being avoided.

The seqlock read is deliberately **bounded** rather than spinning to convergence. A reader that retries until it wins is unbounded when the writer is preempted between its two counter updates, which on an audio thread is no better than the lock this replaces. `Load()` gives up after a few attempts and returns the caller's previous value, so the read is wait-free. Reusing a rotation for one buffer is inaudible; missing a deadline is not.

`Process()` now latches all three once at the top of the block. That is also more correct than reading them where they were read before: `ProcessingGroup` interpolates the rotation across the buffer, so a value that can change partway through is arguably already wrong.

`mutex_` is unchanged and still guards `audio_elements_` and `processing_groups_` — containers being rebuilt, rather than values being handed over. Nothing that runs continuously during playback takes it now.

### Testing

- `atomic_rotation_test` (new): round trip, the concurrent no-tearing property, and the bounded fallback under a continuous write storm.
- `ObrImplTest.TestConcurrentHeadRotationDuringProcessing` (new): renders while a second thread sweeps head rotation and toggles both flags.
- Both are clean under ThreadSanitizer.
- The existing 65 renderer and processing-group tests pass unchanged.

No public API change.

### Noticed while measuring, reported separately

Running `Process()` inside a `[[clang::nonblocking]]` region under RealtimeSanitizer shows 4 `malloc` / 4 `free` per render call, from the per-block `AudioBuffer group_output` and from `PeakLimiter`. That is independent of this change and of any locking — it happens single-threaded with head tracking disabled — so it is filed on its own rather than bundled here.