### PR TITLE
Fix binaural OBR crash when using oar_set_metadata_unit_to_process (#29)

### DIFF
--- a/include/oar.h
+++ b/include/oar.h
@@ -215,8 +215,12 @@ int oar_update_audio_element_data(oar_t *oar, uint32_t id,
  * @param     [in] samples : Number of samples to process as a unit
  * @return    0 on success, -1 for invalid parameters, -18 for unsupported
  *            metadata type
- * @note      Currently only ck_metadata_object_positions is supported for
- *            setting
+ * @note      Currently only ck_metadata_object_positions is supported.
+ *            samples must be in range (0, samples_per_channel].
+ *            For non-binaural rendering, this controls sub-frame position
+ *            update granularity. For binaural rendering, OBR always uses
+ *            config.samples_per_channel as buffer_size_per_channel; this
+ *            setting has no effect on binaural processing.
  */
 int oar_set_metadata_unit_to_process(oar_t *oar, oar_metadata_type_t type,
                                      uint32_t samples);

--- a/include/oar.h
+++ b/include/oar.h
@@ -219,8 +219,11 @@ int oar_update_audio_element_data(oar_t *oar, uint32_t id,
  *            samples must be in range (0, samples_per_channel].
  *            For non-binaural rendering, this controls sub-frame position
  *            update granularity. For binaural rendering, OBR always uses
- *            config.samples_per_channel as buffer_size_per_channel; this
- *            setting has no effect on binaural processing.
+ *            config.samples_per_channel as buffer_size_per_channel, so
+ *            sub-frame rendering is not supported. Position metadata is
+ *            still applied at frame granularity (one update per render
+ *            call), but the sub-frame sample size setting itself has no
+ *            additional effect on binaural processing.
  */
 int oar_set_metadata_unit_to_process(oar_t *oar, oar_metadata_type_t type,
                                      uint32_t samples);

--- a/src/oar.c
+++ b/src/oar.c
@@ -407,6 +407,13 @@ int oar_set_metadata_unit_to_process(oar_t *oar, oar_metadata_type_t type,
     return ck_oar_error_notsup;
   }
 
+  if (samples == 0 || oar->config.samples_per_channel < samples) {
+    warning(
+        "metadata unit samples (%u) is invalid for samples_per_channel (%u).",
+        samples, oar->config.samples_per_channel);
+    return ck_oar_error_inval;
+  }
+
   oar->metadata_samples[type] = samples;
 
   return ck_oar_ok;

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -27,8 +27,8 @@
 #include "oar_base.h"
 #include "oar_metadata.h"
 #include "oar_utils.h"
-#include "renderer_library_manager.h"
 #include "renderer_library_api.h"
+#include "renderer_library_manager.h"
 
 typedef struct AudioElementsRenderer {
   audio_renderer_base_t base;
@@ -61,103 +61,42 @@ static int audio_elements_renderer_private_object_based_elements_count(
   return count;
 }
 
-static int audio_elements_renderer_sub_frames_apply_positions(
-    audio_elements_renderer_t *self, oar_audio_block_t *block,
-    uint32_t sub_frame_samples) {
-  uint32_t total_samples = block->samples_per_channel;
-  uint32_t processed_samples = 0;
+static int audio_elements_renderer_apply_frame_positions(
+    audio_elements_renderer_t *self) {
+  int n = vector_size(self->elements);
 
-  while (processed_samples < total_samples) {
-    uint32_t current_unit_samples = sub_frame_samples;
-    uint32_t remaining_samples = total_samples - processed_samples;
+  for (int i = 0; i < n; i++) {
+    audio_element_context_t *ctx = def_value_wrap_type_ptr(
+        audio_element_context_t, vector_at(self->elements, i));
+    if (!ctx->rendering_metadata.positions) continue;
+
+    uint32_t sample_position = ctx->rendering_metadata.positions->start;
     uint32_t accumulated_duration = 0;
+    oar_metadata_t *current_metadata = 0;
 
-    int n = vector_size(self->elements);
+    int m = queue_length(ctx->rendering_metadata.positions->metadatas);
+    for (int j = 0; j < m; j++) {
+      oar_metadata_t *metadata = def_value_wrap_optional_type_ptr(
+          oar_metadata_t,
+          queue_at(ctx->rendering_metadata.positions->metadatas, j));
+      if (!metadata || metadata->type != ck_metadata_object_positions) continue;
 
-    if (remaining_samples < sub_frame_samples)
-      current_unit_samples = remaining_samples;
-
-    for (int i = 0; i < n; i++) {
-      audio_element_context_t *ctx = def_value_wrap_type_ptr(
-          audio_element_context_t, vector_at(self->elements, i));
-      if (!ctx->rendering_metadata.positions) continue;
-
-      uint32_t sample_position =
-          processed_samples + ctx->rendering_metadata.positions->start;
-      // Find the current position metadata for this sample position
-      oar_metadata_t *current_metadata = 0;
-      int m = queue_length(ctx->rendering_metadata.positions->metadatas);
-      for (int j = 0; j < m; j++) {
-        oar_metadata_t *metadata = def_value_wrap_optional_type_ptr(
-            oar_metadata_t,
-            queue_at(ctx->rendering_metadata.positions->metadatas, j));
-        if (!metadata || metadata->type != ck_metadata_object_positions)
-          continue;
-
-        if (sample_position >= accumulated_duration &&
-            sample_position < accumulated_duration + metadata->duration) {
-          // Create a constant position metadata for this specific sample
-          // position
-          uint32_t relative_pos = sample_position - accumulated_duration;
-          current_metadata = metadata_constant_polar_positions_create(
-              metadata, relative_pos, current_unit_samples);
-          break;
-        }
-
-        accumulated_duration += metadata->duration;
+      if (sample_position >= accumulated_duration &&
+          sample_position < accumulated_duration + metadata->duration) {
+        uint32_t relative_pos = sample_position - accumulated_duration;
+        current_metadata = metadata_constant_polar_positions_create(
+            metadata, relative_pos, self->base.block.samples_per_channel);
+        break;
       }
-
-      if (current_metadata) {
-        // Apply position metadata if found
-        if (self->base.lib && self->base.lib->metadata_update)
-          self->base.lib->metadata_update(&self->base.ctx, i, current_metadata);
-        metadata_delete(current_metadata);
-      }
+      accumulated_duration += metadata->duration;
     }
 
-    oar_audio_block_t sub_block;
-    sub_block.channels = self->channels_count;
-    sub_block.samples_per_channel = current_unit_samples;
-
-    sub_block.data =
-        def_malloc(float, (sub_block.channels * sub_block.samples_per_channel));
-    if (!sub_block.data) return ck_oar_error_nomem;
-
-    oar_audio_block_t sub_out_block;
-    sub_out_block.channels = block->channels;
-    sub_out_block.samples_per_channel = current_unit_samples;
-
-    sub_out_block.data = def_malloc(
-        float, (sub_out_block.channels * sub_out_block.samples_per_channel));
-    if (!sub_out_block.data) {
-      def_free(sub_block.data);
-      return ck_oar_error_nomem;
+    if (current_metadata) {
+      if (self->base.lib && self->base.lib->metadata_update)
+        self->base.lib->metadata_update(&self->base.ctx, i, current_metadata);
+      metadata_delete(current_metadata);
     }
-
-    for (uint32_t ch = 0; ch < sub_block.channels; ch++)
-      memcpy(sub_block.data + ch * sub_block.samples_per_channel,
-             self->base.block.data + ch * self->base.block.samples_per_channel +
-                 processed_samples,
-             (current_unit_samples * sizeof(float)));
-
-    // Render this sub-frame
-    if (self->base.lib && self->base.lib->render) {
-      self->base.lib->render(&self->base.ctx, &sub_block, &sub_out_block);
-
-      for (uint32_t ch = 0; ch < sub_out_block.channels; ch++)
-        memcpy(
-            block->data + ch * block->samples_per_channel + processed_samples,
-            sub_out_block.data + ch * sub_out_block.samples_per_channel,
-            (current_unit_samples * sizeof(float)));
-    }
-
-    // Clean up allocated memory
-    def_free(sub_block.data);
-    def_free(sub_out_block.data);
-
-    processed_samples += current_unit_samples;
   }
-
   return ck_oar_ok;
 }
 
@@ -347,6 +286,20 @@ int audio_elements_renderer_add_data(audio_renderer_base_t *base,
     return ck_oar_error_inval;
   }
 
+  // Validate block dimensions match config to prevent OBR buffer size mismatch
+  // crash and heap overflow from inconsistent stride/length in memcpy.
+  if (block->samples_per_channel != self->base.ctx.samples_per_frame) {
+    warning("Input block samples per channel (%u) don't match config (%u)",
+            block->samples_per_channel, self->base.ctx.samples_per_frame);
+    return ck_oar_error_inval;
+  }
+
+  if (block->channels != (uint32_t)rid_channels_count(ctx->rid)) {
+    warning("Input block channels (%u) don't match element channels (%u)",
+            block->channels, rid_channels_count(ctx->rid));
+    return ck_oar_error_inval;
+  }
+
   if (self->elements_updated) {
     if (!self->base.block.data) {
       debug("channels %d, samples %d", self->channels_count,
@@ -358,9 +311,12 @@ int audio_elements_renderer_add_data(audio_renderer_base_t *base,
       }
       self->base.block.samples_per_channel = block->samples_per_channel;
     } else if (block->channels < self->channels_count) {
+      /* A new element was added after the initial allocation, increasing
+       * channels_count. Realloc to fit all elements' channels. */
       float *data =
           def_realloc(self->base.block.data, float,
                       (self->channels_count * block->samples_per_channel));
+
       if (!data) return ck_oar_error_nomem;
       self->base.block.data = data;
     }
@@ -420,9 +376,14 @@ int audio_elements_renderer_render(audio_renderer_base_t *base,
   int ret = ck_oar_error_inval;
   if (!self || !output_block) return ck_oar_error_inval;
 
-  // Binaural (OBR) always renders the full frame using
-  // config.samples_per_channel. Sub-frame position updates are not applied
-  // for binaural because OBR fixes buffer_size_per_channel at creation time.
+  // Frame-granularity position update: forward object-based element positions
+  // to OBR before rendering. OBR fixes buffer_size_per_channel at creation
+  // time, so sub-frame rendering is not supported, but position metadata still
+  // needs to be applied at frame granularity.
+  if (audio_elements_renderer_private_object_based_elements_count(self))
+    audio_elements_renderer_apply_frame_positions(self);
+
+  // Full-frame rendering (OBR buffer_size_per_channel == samples_per_channel)
   if (self->base.lib && self->base.lib->render) {
     ret = self->base.lib->render(&self->base.ctx, &self->base.block,
                                  output_block);

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -420,15 +420,10 @@ int audio_elements_renderer_render(audio_renderer_base_t *base,
   int ret = ck_oar_error_inval;
   if (!self || !output_block) return ck_oar_error_inval;
 
-  // if includes object-based renderers, use sub-frame rendering with position
-  // updates
-  if (audio_elements_renderer_private_object_based_elements_count(self)) {
-    ret = audio_elements_renderer_sub_frames_apply_positions(
-        self, output_block,
-        self->base.metadata_samples_ref[ck_metadata_object_positions]);
-  }
-  // Render the entire block at once using the underlying self library
-  else if (self->base.lib && self->base.lib->render) {
+  // Binaural (OBR) always renders the full frame using
+  // config.samples_per_channel. Sub-frame position updates are not applied
+  // for binaural because OBR fixes buffer_size_per_channel at creation time.
+  if (self->base.lib && self->base.lib->render) {
     ret = self->base.lib->render(&self->base.ctx, &self->base.block,
                                  output_block);
   }

--- a/tests/examples/BUILD.bazel
+++ b/tests/examples/BUILD.bazel
@@ -47,3 +47,12 @@ cc_test(
         "//:oar",
     ],
 )
+
+cc_test(
+    name = "test_metadata_unit_processing",
+    srcs = ["test_metadata_unit_processing.c"],
+    deps = [
+        "//:oar",
+    ],
+)
+

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(test_scene_based_rendering test_scene_based_rendering.c)
 # Add the test for object-based rendering
 add_executable(test_object_based_rendering test_object_based_rendering.c)
 
+# Add the test for metadata unit processing (binaural OBR sub-frame)
+add_executable(test_metadata_unit_processing test_metadata_unit_processing.c)
+
 # Link the tests against the main oar library.
 # The 'oar' target is defined in the parent CMakeLists.txt,
 # so it's accessible here.
@@ -19,6 +22,7 @@ target_link_libraries(test_audio_element_types PRIVATE oar)
 target_link_libraries(test_channel_based_rendering PRIVATE oar)
 target_link_libraries(test_scene_based_rendering PRIVATE oar)
 target_link_libraries(test_object_based_rendering PRIVATE oar)
+target_link_libraries(test_metadata_unit_processing PRIVATE oar)
 
 # Include directories are inherited from the parent project,
 # so oar.h and other headers should be found automatically.
@@ -28,10 +32,13 @@ set_property(TARGET test_audio_element_types PROPERTY C_STANDARD 99)
 set_property(TARGET test_channel_based_rendering PROPERTY C_STANDARD 99)
 set_property(TARGET test_scene_based_rendering PROPERTY C_STANDARD 99)
 set_property(TARGET test_object_based_rendering PROPERTY C_STANDARD 99)
+set_property(TARGET test_metadata_unit_processing PROPERTY C_STANDARD 99)
+
 if(NOT MSVC)
   target_link_libraries(test_channel_based_rendering PRIVATE m)
   target_link_libraries(test_scene_based_rendering PRIVATE m)
   target_link_libraries(test_object_based_rendering PRIVATE m)
+  target_link_libraries(test_metadata_unit_processing PRIVATE m)
 endif()
 
 # The HOA LFE test exercises the 120 Hz LFE low-pass, which is only compiled

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -24,6 +24,14 @@ target_link_libraries(test_scene_based_rendering PRIVATE oar)
 target_link_libraries(test_object_based_rendering PRIVATE oar)
 target_link_libraries(test_metadata_unit_processing PRIVATE oar)
 
+# Register tests with CTest so they run automatically in CI.
+add_test(NAME test_audio_element_types COMMAND test_audio_element_types)
+add_test(NAME test_channel_based_rendering COMMAND test_channel_based_rendering)
+add_test(NAME test_scene_based_rendering COMMAND test_scene_based_rendering)
+add_test(NAME test_object_based_rendering COMMAND test_object_based_rendering)
+add_test(NAME test_metadata_unit_processing COMMAND test_metadata_unit_processing)
+
+
 # Include directories are inherited from the parent project,
 # so oar.h and other headers should be found automatically.
 

--- a/tests/examples/test_metadata_unit_processing.c
+++ b/tests/examples/test_metadata_unit_processing.c
@@ -1,0 +1,956 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/**
+ * @file test_metadata_unit_processing.c
+ * @brief Test cases for oar_set_metadata_unit_to_process with binaural
+ * rendering.
+ *
+ * Test matrix:
+ *   TC1: binaural, add_group → set_metadata(32) → expect success
+ *   TC2: binaural, add_group → set_metadata(512) → render → success
+ *   TC3: stereo, add_group → set_metadata(32) → render → success
+ *   TC4: binaural, set_metadata(32) → add_group → render → success + non-silent
+ *   TC5: binaural, add_group → render (no set_metadata call) → success
+ *   TC6: Invalid parameters → expect errors
+ *   TC7: binaural, set_metadata(32) → set_metadata(64) → add_group → render
+ *   TC8: binaural, non-divisor samples → expect success
+ *   TC9: binaural, zero samples → expect error
+ *   TC10: binaural, samples > frame → expect error
+ *   TC11: stereo, non-divisor samples → expect success
+ *   TC12: stereo, varying positions across sub-frames → verify position update
+ */
+
+#include <math.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#else
+#include <process.h>
+#include <windows.h>
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "oar.h"
+
+#define TEST_SAMPLING_RATE 48000
+#define TEST_SAMPLES_PER_CHANNEL 512
+#define TEST_SUB_FRAME_SAMPLES 32
+#define TEST_SUB_FRAME_SAMPLES_ALT 64
+#define TEST_ELEMENT_ID 1
+
+static void generate_sine_wave(float *buffer, uint32_t samples, float frequency,
+                               float sample_rate) {
+  for (uint32_t i = 0; i < samples; ++i) {
+    buffer[i] = (float)sin(2.0 * M_PI * frequency * ((float)i / sample_rate));
+  }
+}
+
+static oar_metadata_t *create_position_metadata(polar_t position,
+                                                uint32_t duration) {
+  oar_metadata_t *metadata = (oar_metadata_t *)malloc(sizeof(oar_metadata_t));
+  if (!metadata) return NULL;
+
+  metadata->type = ck_metadata_object_positions;
+  metadata->duration = (int)duration;
+  metadata->object_positions.param_type = ck_param_constant;
+  metadata->object_positions.position_type = ck_polar;
+  metadata->object_positions.num_objects = 1;
+  metadata->object_positions.polar_positions[0].azimuth = position.azimuth;
+  metadata->object_positions.polar_positions[0].elevation = position.elevation;
+  metadata->object_positions.polar_positions[0].distance = position.distance;
+
+  return metadata;
+}
+
+static int is_output_non_silent(const float *data, uint32_t count) {
+  for (uint32_t i = 0; i < count; ++i) {
+    if (fabs(data[i]) > 1e-9f) return 1;
+  }
+  return 0;
+}
+
+static int add_object_element_and_data(oar_t *oar, uint32_t *out_channels,
+                                       float **out_input_data) {
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0) return -1;
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_object_based;
+  elem_cfg.obc.num_objects = 1;
+  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
+
+  if (oar_add_audio_element(oar, gid, TEST_ELEMENT_ID, &elem_cfg) != 0)
+    return -1;
+
+  uint32_t input_channels =
+      oar_get_number_of_audio_element_channels(oar, TEST_ELEMENT_ID);
+
+  oar_audio_block_t input_data;
+  input_data.channels = input_channels;
+  input_data.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  input_data.data = (float *)malloc(input_channels * TEST_SAMPLES_PER_CHANNEL *
+                                    sizeof(float));
+  if (!input_data.data) return -1;
+
+  generate_sine_wave(input_data.data, TEST_SAMPLES_PER_CHANNEL, 440.0f,
+                     (float)TEST_SAMPLING_RATE);
+  oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data);
+
+  polar_t position = {30.0f, 0.0f, 1.0f};
+  oar_metadata_t *pos_meta =
+      create_position_metadata(position, TEST_SAMPLES_PER_CHANNEL);
+  if (pos_meta) {
+    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, pos_meta);
+    free(pos_meta);
+  }
+
+  *out_channels = oar_get_number_of_output_channels(oar);
+  *out_input_data = input_data.data;
+  return 0;
+}
+
+/* Like add_object_element_and_data but without adding default position
+ * metadata. Used by TC12 which provides its own position metadata. */
+static int add_object_element_without_position(oar_t *oar,
+                                               uint32_t *out_channels,
+                                               float **out_input_data) {
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0) return -1;
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_object_based;
+  elem_cfg.obc.num_objects = 1;
+  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
+
+  if (oar_add_audio_element(oar, gid, TEST_ELEMENT_ID, &elem_cfg) != 0)
+    return -1;
+
+  uint32_t input_channels =
+      oar_get_number_of_audio_element_channels(oar, TEST_ELEMENT_ID);
+
+  oar_audio_block_t input_data;
+  input_data.channels = input_channels;
+  input_data.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  input_data.data = (float *)malloc(input_channels * TEST_SAMPLES_PER_CHANNEL *
+                                    sizeof(float));
+  if (!input_data.data) return -1;
+
+  generate_sine_wave(input_data.data, TEST_SAMPLES_PER_CHANNEL, 440.0f,
+                     (float)TEST_SAMPLING_RATE);
+  oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data);
+
+  *out_channels = oar_get_number_of_output_channels(oar);
+  *out_input_data = input_data.data;
+  return 0;
+}
+
+/* TC1: set_metadata(32) after add_group (binaural) — should succeed */
+
+static int test_set_metadata_after_add_group_binaural() {
+  printf("\n===== TC1: set_metadata(32) after add_group (binaural) =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) {
+    fprintf(stderr, "FAIL: Failed to create OAR instance.\n");
+    return -1;
+  }
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    fprintf(stderr, "FAIL: Failed to setup binaural OAR.\n");
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret != 0) {
+    fprintf(stderr,
+            "FAIL: set_metadata(32) failed after add_group (binaural). "
+            "Expected success, got %d.\n",
+            ret);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf("PASS: set_metadata(32) succeeded after add_group (binaural).\n");
+
+  free(input_data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC2: set_metadata(512) after add_group (equal, no-op) — should succeed */
+static int test_set_metadata_equal_after_add_group() {
+  printf(
+      "\n===== TC2: set_metadata(512) after add_group (equal, no-op) =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SAMPLES_PER_CHANNEL);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: set_metadata(512) returned %d, expected 0.\n", ret);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+  memset(output.data, 0,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+
+  ret = oar_render(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
+    return -1;
+  }
+
+  printf("PASS: set_metadata(512) + render succeeded.\n");
+  return 0;
+}
+
+/* TC3: set_metadata(32) with stereo layout — should succeed */
+static int test_set_metadata_stereo() {
+  printf("\n===== TC3: set_metadata(32) with stereo layout =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_stereo;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: set_metadata(32) on stereo returned %d\n", ret);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+  memset(output.data, 0,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+
+  ret = oar_render(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render on stereo returned %d\n", ret);
+    return -1;
+  }
+
+  printf("PASS: stereo + set_metadata(32) + render succeeded.\n");
+  return 0;
+}
+
+/* TC4: set_metadata(32) before add_group (binaural) — should succeed */
+static int test_set_metadata_before_add_group_binaural() {
+  printf("\n===== TC4: set_metadata(32) before add_group (binaural) =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: set_metadata(32) before add_group returned %d\n",
+            ret);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+  memset(output.data, 0,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+
+  ret = oar_render(oar, &output);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  if (!is_output_non_silent(output.data, total_samples)) {
+    fprintf(stderr,
+            "FAIL: output is silent after sub-frame rendering. "
+            "OBR may not have processed the 32-sample blocks.\n");
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf(
+      "PASS: set_metadata(32) before add_group + render succeeded "
+      "(output is non-silent).\n");
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC5: default (no set_metadata call, binaural) — backward compatibility */
+static int test_default_no_set_metadata_binaural() {
+  printf("\n===== TC5: default (no set_metadata call, binaural) =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+  memset(output.data, 0,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+
+  int ret = oar_render(oar, &output);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d (default path)\n", ret);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  if (!is_output_non_silent(output.data, total_samples)) {
+    fprintf(stderr, "FAIL: output is silent in default path.\n");
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf("PASS: default (no set_metadata) + render succeeded (non-silent).\n");
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC6: invalid parameters — NULL oar and unsupported metadata type */
+static int test_invalid_parameters() {
+  printf("\n===== TC6: invalid parameters =====\n");
+
+  int ret = oar_set_metadata_unit_to_process(NULL, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret == 0) {
+    fprintf(stderr, "FAIL: set_metadata(NULL) succeeded, expected error.\n");
+    return -1;
+  }
+  printf("  NULL oar: returned %d (expected error) OK\n", ret);
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_gain,
+                                         TEST_SUB_FRAME_SAMPLES);
+  if (ret == 0) {
+    fprintf(
+        stderr,
+        "FAIL: set_metadata(ck_metadata_gain) succeeded, expected error.\n");
+    oar_destroy(oar);
+    return -1;
+  }
+  printf("  unsupported type: returned %d (expected error) OK\n", ret);
+
+  oar_destroy(oar);
+  printf("PASS: invalid parameters correctly rejected.\n");
+  return 0;
+}
+
+/* TC7: multiple set_metadata before add_group — last value wins */
+static int test_multiple_set_metadata_before_add_group() {
+  printf("\n===== TC7: multiple set_metadata before add_group =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: first set_metadata(32) returned %d\n", ret);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                         TEST_SUB_FRAME_SAMPLES_ALT);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: second set_metadata(64) returned %d\n", ret);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+  memset(output.data, 0,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+
+  ret = oar_render(oar, &output);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  if (!is_output_non_silent(output.data, total_samples)) {
+    fprintf(stderr, "FAIL: output is silent after multiple set_metadata.\n");
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf(
+      "PASS: multiple set_metadata (last=64) + render succeeded "
+      "(non-silent).\n");
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC8: binaural, non-divisor samples → expect success */
+static int test_binaural_non_divisor_accepted() {
+  printf("\n===== TC8: binaural non-divisor accepted =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
+  oar_destroy(oar);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: non-divisor 100 rejected for binaural (%d).\n", ret);
+    return -1;
+  }
+  printf("PASS: non-divisor 100 accepted for binaural.\n");
+  return 0;
+}
+
+/* TC9: zero samples → expect error */
+static int test_zero_samples_rejected() {
+  printf("\n===== TC9: zero samples rejected =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 0);
+  oar_destroy(oar);
+
+  if (ret == 0) {
+    fprintf(stderr, "FAIL: zero samples accepted.\n");
+    return -1;
+  }
+  printf("PASS: zero samples rejected (%d).\n", ret);
+  return 0;
+}
+
+/* TC10: samples > frame → expect error */
+static int test_exceeds_frame_rejected() {
+  printf("\n===== TC10: samples > frame rejected =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SAMPLES_PER_CHANNEL * 2);
+  oar_destroy(oar);
+
+  if (ret == 0) {
+    fprintf(stderr, "FAIL: samples > frame accepted.\n");
+    return -1;
+  }
+  printf("PASS: samples > frame rejected (%d).\n", ret);
+  return 0;
+}
+
+/* TC11: stereo, non-divisor samples → expect success */
+static int test_stereo_non_divisor_accepted() {
+  printf("\n===== TC11: stereo non-divisor accepted =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_stereo;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
+  oar_destroy(oar);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: non-divisor 100 rejected for stereo (%d).\n", ret);
+    return -1;
+  }
+  printf("PASS: non-divisor 100 accepted for stereo.\n");
+  return 0;
+}
+
+/* TC12: stereo, varying positions across sub-frames → verify position update */
+static int test_stereo_varying_positions_sub_frame() {
+  printf("\n===== TC12: stereo varying positions sub-frame =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_stereo;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  if (ret != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  if (add_object_element_without_position(oar, &out_channels, &input_data) !=
+      0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  /* Provide two position metadata entries: first half left, second half right.
+   * In stereo layout: ch0 = +30° (left speaker), ch1 = -30° (right speaker).
+   * Use ±80° so positions are clearly on one side, producing asymmetric gain.
+   * First half: +80° (far left) → ch0 dominant
+   * Second half: -80° (far right) → ch1 dominant */
+  polar_t pos_left = {80.0f, 0.0f, 1.0f};
+  polar_t pos_right = {-80.0f, 0.0f, 1.0f};
+
+  oar_metadata_t *meta_left =
+      create_position_metadata(pos_left, TEST_SAMPLES_PER_CHANNEL / 2);
+  oar_metadata_t *meta_right =
+      create_position_metadata(pos_right, TEST_SAMPLES_PER_CHANNEL / 2);
+
+  if (meta_left) {
+    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_left);
+    free(meta_left);
+  }
+  if (meta_right) {
+    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_right);
+    free(meta_right);
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
+  if (!output.data) {
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  ret = oar_render(oar, &output);
+
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  /* Verify: left channel first half energy > second half, right channel vice
+   * versa */
+  uint32_t half = TEST_SAMPLES_PER_CHANNEL / 2;
+  float left_first_half = 0.0f, left_second_half = 0.0f;
+  float right_first_half = 0.0f, right_second_half = 0.0f;
+
+  for (uint32_t i = 0; i < half; i++) {
+    left_first_half += fabsf(output.data[i]);
+    right_first_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
+  }
+  for (uint32_t i = half; i < TEST_SAMPLES_PER_CHANNEL; i++) {
+    left_second_half += fabsf(output.data[i]);
+    right_second_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
+  }
+
+  if (left_first_half <= left_second_half ||
+      right_second_half <= right_first_half) {
+    fprintf(stderr,
+            "FAIL: sub-frame position update not reflected in output.\n"
+            "  Left ch:  first_half=%.4f, second_half=%.4f\n"
+            "  Right ch: first_half=%.4f, second_half=%.4f\n",
+            left_first_half, left_second_half, right_first_half,
+            right_second_half);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf("PASS: sub-frame position updates reflected in output.\n");
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* Test function table for child-process dispatch. */
+typedef int (*test_fn_t)(void);
+static test_fn_t g_test_table[] = {
+    test_set_metadata_after_add_group_binaural,  /* 0  TC1 */
+    test_set_metadata_equal_after_add_group,     /* 1  TC2 */
+    test_set_metadata_stereo,                    /* 2  TC3 */
+    test_set_metadata_before_add_group_binaural, /* 3  TC4 */
+    test_default_no_set_metadata_binaural,       /* 4  TC5 */
+    test_invalid_parameters,                     /* 5  TC6 */
+    test_multiple_set_metadata_before_add_group, /* 6  TC7 */
+    test_binaural_non_divisor_accepted,          /* 7  TC8 */
+    test_zero_samples_rejected,                  /* 8  TC9 */
+    test_exceeds_frame_rejected,                 /* 9  TC10 */
+    test_stereo_non_divisor_accepted,            /* 10 TC11 */
+    test_stereo_varying_positions_sub_frame,     /* 11 TC12 */
+};
+#define NUM_TESTS (int)(sizeof(g_test_table) / sizeof(g_test_table[0]))
+
+static const char *g_test_names[] = {
+    "TC1", "TC2", "TC3", "TC4",  "TC5",  "TC6",
+    "TC7", "TC8", "TC9", "TC10", "TC11", "TC12",
+};
+
+/* Run a test function in a separate child process so that a crash
+ * does not prevent subsequent tests from running.
+ *
+ * On Linux/macOS, fork() + waitpid() is used.
+ * On Windows (MSVC), _spawnl(_P_WAIT, ...) re-invokes this executable
+ * with "--child <index>" to run a single test in a child process.
+ * Both paths provide identical crash isolation behaviour. */
+static int run_test_in_child(int test_index) {
+  const char *name = g_test_names[test_index];
+
+#ifndef _WIN32
+  test_fn_t test_fn = g_test_table[test_index];
+  fflush(stdout);
+  fflush(stderr);
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    perror("fork");
+    return -1;
+  }
+
+  if (pid == 0) {
+    int ret = test_fn();
+    fflush(stdout);
+    fflush(stderr);
+    _exit(ret);
+  }
+
+  int status = 0;
+  waitpid(pid, &status, 0);
+
+  if (WIFEXITED(status)) {
+    int exit_code = WEXITSTATUS(status);
+    if (exit_code == 0) {
+      printf("[%s] PASSED (exit 0)\n", name);
+      return 0;
+    } else {
+      printf("[%s] FAILED (exit %d)\n", name, exit_code);
+      return -1;
+    }
+  } else if (WIFSIGNALED(status)) {
+    int sig = WTERMSIG(status);
+    printf("[%s] CRASHED (signal %d: %s)\n", name, sig,
+           sig == SIGABRT ? "SIGABRT" : "other");
+    return -1;
+  }
+
+  printf("[%s] UNKNOWN failure\n", name);
+  return -1;
+#else
+  /* Windows: spawn a child process that runs a single test. */
+  char index_str[16];
+  char exe_path[1024];
+  DWORD len = GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
+  if (len == 0 || len >= sizeof(exe_path)) {
+    fprintf(stderr, "[%s] FAILED: cannot get executable path\n", name);
+    return -1;
+  }
+
+  snprintf(index_str, sizeof(index_str), "%d", test_index);
+
+  int exit_code =
+      _spawnl(_P_WAIT, exe_path, exe_path, "--child", index_str, NULL);
+
+  if (exit_code == 0) {
+    printf("[%s] PASSED (exit 0)\n", name);
+    return 0;
+  } else if (exit_code == -1) {
+    printf("[%s] FAILED: spawn error\n", name);
+    return -1;
+  } else {
+    /* On Windows, a crash typically yields exit code 3
+     * (STATUS_ACCESS_VIOLATION) or similar non-zero codes. We treat any
+     * non-zero exit as failure. */
+    printf("[%s] FAILED/CRASHED (exit %d)\n", name, exit_code);
+    return -1;
+  }
+#endif
+}
+
+int main(int argc, char *argv[]) {
+  /* Child-process mode: run a single test by index and return its result.
+   * Used by _spawnl on Windows to achieve crash isolation. */
+  if (argc >= 3 && strcmp(argv[1], "--child") == 0) {
+    int index = atoi(argv[2]);
+    if (index < 0 || index >= NUM_TESTS) {
+      return -1;
+    }
+    int ret = g_test_table[index]();
+    fflush(stdout);
+    fflush(stderr);
+    return ret;
+  }
+
+  printf("========================================\n");
+  printf("Metadata Unit Processing Tests\n");
+  printf("  samples_per_channel: %d\n", TEST_SAMPLES_PER_CHANNEL);
+  printf("  sub_frame_samples:   %d\n", TEST_SUB_FRAME_SAMPLES);
+  printf("  sampling_rate:       %d\n", TEST_SAMPLING_RATE);
+  printf("========================================\n");
+
+  int result = 0;
+  int tc_results[NUM_TESTS];
+
+  for (int i = 0; i < NUM_TESTS; i++) {
+    printf("\n--- Running %s ---\n", g_test_names[i]);
+    tc_results[i] = run_test_in_child(i);
+    result |= (tc_results[i] != 0) ? 1 : 0;
+  }
+
+  printf("\n========================================\n");
+  printf("Test Summary:\n");
+  printf("  TC1 (set_metadata after add_group):   %s\n",
+         tc_results[0] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC2 (set_metadata equal, no-op):     %s\n",
+         tc_results[1] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC3 (stereo + set_metadata):          %s\n",
+         tc_results[2] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC4 (set_metadata before add_group):  %s\n",
+         tc_results[3] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC5 (default, no set_metadata):       %s\n",
+         tc_results[4] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC6 (invalid parameters):             %s\n",
+         tc_results[5] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC7 (multiple set_metadata):          %s\n",
+         tc_results[6] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC8 (binaural non-divisor):           %s\n",
+         tc_results[7] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC9 (zero samples):                  %s\n",
+         tc_results[8] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC10 (samples > frame):               %s\n",
+         tc_results[9] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC11 (stereo non-divisor):            %s\n",
+         tc_results[10] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("  TC12 (stereo varying positions):      %s\n",
+         tc_results[11] == 0 ? "PASSED" : "FAILED/CRASHED");
+  printf("========================================\n");
+
+  if (result == 0) {
+    printf("\nAll tests passed.\n");
+  } else {
+    printf("\nSome tests failed or crashed. Review output above.\n");
+  }
+
+  return result;
+}

--- a/tests/examples/test_metadata_unit_processing.c
+++ b/tests/examples/test_metadata_unit_processing.c
@@ -28,8 +28,15 @@
  *   TC10: binaural, samples > frame → expect error
  *   TC11: stereo, non-divisor samples → expect success
  *   TC12: stereo, varying positions across sub-frames → verify position update
+ *   TC13: binaural, mirrored positions (±80°) → outputs differ + ILD flips
+ *   TC14: binaural, position update between frames → takes effect next frame
+ *   TC15: binaural, input block smaller than frame → rejected, no abort
+ *   TC16: binaural, mismatched block sizes across elements → rejected
+ *   TC17: binaural, two elements rendered simultaneously → independent
+ * positions
  */
 
+#include <errno.h>
 #include <math.h>
 #include <signal.h>
 #include <stdio.h>
@@ -55,6 +62,14 @@
 #define TEST_SUB_FRAME_SAMPLES 32
 #define TEST_SUB_FRAME_SAMPLES_ALT 64
 #define TEST_ELEMENT_ID 1
+#define TEST_ELEMENT_ID_2 2
+/* Binaural azimuth for the interaural asymmetry checks. */
+#define TEST_SIDE_AZIMUTH 80.0f
+/* Minimum interaural energy ratio near/far ear at ±80°. */
+#define TEST_ILD_RATIO 1.1f
+/* Minimum RMS difference between two renders, relative to signal RMS,
+ * for them to count as "different". */
+#define TEST_MIN_RELATIVE_DIFF 0.05
 
 static void generate_sine_wave(float *buffer, uint32_t samples, float frequency,
                                float sample_rate) {
@@ -87,8 +102,12 @@ static int is_output_non_silent(const float *data, uint32_t count) {
   return 0;
 }
 
-static int add_object_element_and_data(oar_t *oar, uint32_t *out_channels,
-                                       float **out_input_data) {
+/* Unified helper: adds an object-based element, fills all input channels with
+ * a sine wave, optionally attaches a default position metadata, and submits
+ * the data. Replaces the former add_object_element_and_data and
+ * add_object_element_without_position. */
+static int add_object_element(oar_t *oar, uint32_t *out_channels,
+                              float **out_input_data, int add_position) {
   int gid = oar_add_audio_group(oar);
   if (gid < 0) return -1;
 
@@ -111,16 +130,36 @@ static int add_object_element_and_data(oar_t *oar, uint32_t *out_channels,
                                     sizeof(float));
   if (!input_data.data) return -1;
 
-  generate_sine_wave(input_data.data, TEST_SAMPLES_PER_CHANNEL, 440.0f,
-                     (float)TEST_SAMPLING_RATE);
-  oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data);
+  /* Fill all input channels (not just channel 0) */
+  for (uint32_t ch = 0; ch < input_channels; ch++) {
+    generate_sine_wave(input_data.data + ch * TEST_SAMPLES_PER_CHANNEL,
+                       TEST_SAMPLES_PER_CHANNEL, 440.0f,
+                       (float)TEST_SAMPLING_RATE);
+  }
 
-  polar_t position = {30.0f, 0.0f, 1.0f};
-  oar_metadata_t *pos_meta =
-      create_position_metadata(position, TEST_SAMPLES_PER_CHANNEL);
-  if (pos_meta) {
-    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, pos_meta);
+  if (oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data) != 0) {
+    fprintf(stderr, "FAIL: oar_update_audio_element_data failed.\n");
+    free(input_data.data);
+    return -1;
+  }
+
+  if (add_position) {
+    polar_t position = {30.0f, 0.0f, 1.0f};
+    oar_metadata_t *pos_meta =
+        create_position_metadata(position, TEST_SAMPLES_PER_CHANNEL);
+    if (!pos_meta) {
+      fprintf(stderr, "FAIL: create_position_metadata returned NULL.\n");
+      free(input_data.data);
+      return -1;
+    }
+    int ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, pos_meta);
     free(pos_meta);
+    if (ret != 0) {
+      fprintf(stderr, "FAIL: oar_update_audio_element_metadata failed (%d).\n",
+              ret);
+      free(input_data.data);
+      return -1;
+    }
   }
 
   *out_channels = oar_get_number_of_output_channels(oar);
@@ -128,47 +167,123 @@ static int add_object_element_and_data(oar_t *oar, uint32_t *out_channels,
   return 0;
 }
 
-/* Like add_object_element_and_data but without adding default position
- * metadata. Used by TC12 which provides its own position metadata. */
-static int add_object_element_without_position(oar_t *oar,
-                                               uint32_t *out_channels,
-                                               float **out_input_data) {
-  int gid = oar_add_audio_group(oar);
-  if (gid < 0) return -1;
+/* Head-shadow ILD is weak below ~1.5 kHz, so a pure 440 Hz tone would make
+ * the interaural asymmetry checks in TC13/TC14 fragile. Use a stimulus with
+ * both low- and high-frequency content instead. */
+static void generate_test_stimulus(float *buffer, uint32_t samples,
+                                   float sample_rate) {
+  for (uint32_t i = 0; i < samples; ++i) {
+    float t = (float)i / sample_rate;
+    buffer[i] = 0.45f * (float)sin(2.0 * M_PI * 440.0 * t) +
+                0.45f * (float)sin(2.0 * M_PI * 3500.0 * t);
+  }
+}
 
+static int add_object_element_to_group(oar_t *oar, int gid,
+                                       uint32_t element_id) {
   oar_audio_element_config_t elem_cfg;
   memset(&elem_cfg, 0, sizeof(elem_cfg));
   elem_cfg.type = ck_object_based;
   elem_cfg.obc.num_objects = 1;
   memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
 
-  if (oar_add_audio_element(oar, gid, TEST_ELEMENT_ID, &elem_cfg) != 0)
-    return -1;
-
-  uint32_t input_channels =
-      oar_get_number_of_audio_element_channels(oar, TEST_ELEMENT_ID);
-
-  oar_audio_block_t input_data;
-  input_data.channels = input_channels;
-  input_data.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  input_data.data = (float *)malloc(input_channels * TEST_SAMPLES_PER_CHANNEL *
-                                    sizeof(float));
-  if (!input_data.data) return -1;
-
-  generate_sine_wave(input_data.data, TEST_SAMPLES_PER_CHANNEL, 440.0f,
-                     (float)TEST_SAMPLING_RATE);
-  oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data);
-
-  *out_channels = oar_get_number_of_output_channels(oar);
-  *out_input_data = input_data.data;
-  return 0;
+  return oar_add_audio_element(oar, gid, element_id, &elem_cfg);
 }
 
-/* TC1: set_metadata(32) after add_group (binaural) — should succeed */
+/* Like add_object_element_to_group but allows specifying num_objects (1-2). */
+static int add_object_element_to_group_n(oar_t *oar, int gid,
+                                         uint32_t element_id, int num_objects) {
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_object_based;
+  elem_cfg.obc.num_objects = num_objects;
+  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
 
-static int test_set_metadata_after_add_group_binaural() {
-  printf("\n===== TC1: set_metadata(32) after add_group (binaural) =====\n");
+  return oar_add_audio_element(oar, gid, element_id, &elem_cfg);
+}
 
+/* Submit a stimulus block of the given size for one element, filling every
+ * input channel. The renderer copies the block, so the buffer is freed here.
+ * Returns the oar_update_audio_element_data result. */
+static int submit_stimulus_block(oar_t *oar, uint32_t element_id,
+                                 uint32_t samples) {
+  uint32_t channels = oar_get_number_of_audio_element_channels(oar, element_id);
+  if (channels == 0) return -1;
+
+  oar_audio_block_t block;
+  block.channels = channels;
+  block.samples_per_channel = samples;
+  block.data = (float *)malloc(channels * samples * sizeof(float));
+  if (!block.data) return -1;
+
+  for (uint32_t c = 0; c < channels; ++c) {
+    generate_test_stimulus(block.data + c * samples, samples,
+                           (float)TEST_SAMPLING_RATE);
+  }
+
+  int ret = oar_update_audio_element_data(oar, element_id, &block);
+  free(block.data);
+  return ret;
+}
+
+static int submit_position(oar_t *oar, uint32_t element_id, float azimuth,
+                           uint32_t duration) {
+  polar_t position = {azimuth, 0.0f, 1.0f};
+  oar_metadata_t *meta = create_position_metadata(position, duration);
+  if (!meta) return -1;
+  int ret = oar_update_audio_element_metadata(oar, element_id, meta);
+  free(meta);
+  return ret;
+}
+
+/* Submit position metadata with two objects at different azimuths for a
+ * num_objects=2 element. Both objects share the same duration. */
+static int submit_position_dual(oar_t *oar, uint32_t element_id, float az1,
+                                float az2, uint32_t duration) {
+  oar_metadata_t meta;
+  memset(&meta, 0, sizeof(meta));
+  meta.type = ck_metadata_object_positions;
+  meta.duration = (int)duration;
+  meta.object_positions.param_type = ck_param_constant;
+  meta.object_positions.position_type = ck_polar;
+  meta.object_positions.num_objects = 2;
+  meta.object_positions.polar_positions[0] = (polar_t){az1, 0.0f, 1.0f};
+  meta.object_positions.polar_positions[1] = (polar_t){az2, 0.0f, 1.0f};
+  return oar_update_audio_element_metadata(oar, element_id, &meta);
+}
+
+static double sum_abs(const float *data, uint32_t count) {
+  double sum = 0.0;
+  for (uint32_t i = 0; i < count; ++i) sum += fabs(data[i]);
+  return sum;
+}
+
+static double rms_of(const float *data, uint32_t count) {
+  double sum = 0.0;
+  for (uint32_t i = 0; i < count; ++i) sum += (double)data[i] * data[i];
+  return sqrt(sum / count);
+}
+
+static double rms_diff(const float *a, const float *b, uint32_t count) {
+  double sum = 0.0;
+  for (uint32_t i = 0; i < count; ++i) {
+    double d = (double)a[i] - b[i];
+    sum += d * d;
+  }
+  return sqrt(sum / count);
+}
+
+/* --- Setup/teardown helpers for TC1-TC7 to reduce config/output boilerplate.
+ * Each TC runs in its own child process (crash isolation), so these helpers
+ * do not introduce shared state — they simply eliminate the repeated
+ * memset(config) / oar_create / output alloc pattern. --- */
+
+/* Create a binaural OAR instance with a single object element (with default
+ * position) and return it along with the output channel count and input data
+ * pointer (caller frees input_data). Returns 0 on success. */
+static int create_binaural_oar_with_element(oar_t **out_oar,
+                                            uint32_t *out_channels,
+                                            float **out_input_data) {
   oar_config_t config;
   memset(&config, 0, sizeof(config));
   config.target_layout = ck_oar_layout_binaural;
@@ -176,16 +291,124 @@ static int test_set_metadata_after_add_group_binaural() {
   config.sampling_rate = TEST_SAMPLING_RATE;
 
   oar_t *oar = oar_create(&config);
-  if (!oar) {
-    fprintf(stderr, "FAIL: Failed to create OAR instance.\n");
+  if (!oar) return -1;
+
+  uint32_t out_ch = 0;
+  float *input_data = NULL;
+  if (add_object_element(oar, &out_ch, &input_data, 1) != 0) {
+    oar_destroy(oar);
     return -1;
   }
 
+  *out_oar = oar;
+  *out_channels = out_ch;
+  *out_input_data = input_data;
+  return 0;
+}
+
+/* Allocate a zeroed output block matching the given channel count. Returns 0
+ * on success. */
+static int alloc_output_block(uint32_t out_channels,
+                              oar_audio_block_t *output) {
+  memset(output, 0, sizeof(*output));
+  output->channels = out_channels;
+  output->samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output->data =
+      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
+  return output->data ? 0 : -1;
+}
+
+/* Render and verify output is non-silent. Returns 0 on success. Cleans up
+ * and sets *out_oar to NULL on failure. */
+static int render_and_check_non_silent(oar_t *oar, oar_audio_block_t *output,
+                                       const char *label) {
+  memset(output->data, 0,
+         output->channels * output->samples_per_channel * sizeof(float));
+  int ret = oar_render(oar, output);
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render returned %d (%s)\n", ret, label);
+    return -1;
+  }
+  uint32_t total = output->channels * output->samples_per_channel;
+  if (!is_output_non_silent(output->data, total)) {
+    fprintf(stderr, "FAIL: output is silent (%s)\n", label);
+    return -1;
+  }
+  return 0;
+}
+
+/* Create a binaural renderer with a single object at the given azimuth,
+ * render `frames` full frames (resubmitting stimulus and position before
+ * each), and copy the last rendered frame into `out`
+ * (2 * TEST_SAMPLES_PER_CHANNEL floats, planar). */
+static int render_binaural_frames(float azimuth, int frames, float *out) {
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  if (out_channels != 2) {
+    fprintf(stderr, "FAIL: expected 2 binaural output channels, got %u.\n",
+            out_channels);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
+  if (!output.data) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret = -1;
+  for (int f = 0; f < frames; ++f) {
+    if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
+        0)
+      goto done;
+    if (submit_position(oar, TEST_ELEMENT_ID, azimuth,
+                        TEST_SAMPLES_PER_CHANNEL) != 0)
+      goto done;
+    memset(output.data, 0,
+           out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+    if (oar_render(oar, &output) != 0) goto done;
+  }
+
+  memcpy(out, output.data,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  ret = 0;
+
+done:
+  free(output.data);
+  oar_destroy(oar);
+  return ret;
+}
+
+/* TC1: set_metadata(32) after add_group (binaural) — should succeed */
+static int test_set_metadata_after_add_group_binaural() {
+  printf("\n===== TC1: set_metadata(32) after add_group (binaural) =====\n");
+
+  oar_t *oar = NULL;
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+  if (create_binaural_oar_with_element(&oar, &out_channels, &input_data) != 0) {
     fprintf(stderr, "FAIL: Failed to setup binaural OAR.\n");
-    oar_destroy(oar);
     return -1;
   }
 
@@ -202,7 +425,6 @@ static int test_set_metadata_after_add_group_binaural() {
   }
 
   printf("PASS: set_metadata(32) succeeded after add_group (binaural).\n");
-
   free(input_data);
   oar_destroy(oar);
   return 0;
@@ -213,21 +435,11 @@ static int test_set_metadata_equal_after_add_group() {
   printf(
       "\n===== TC2: set_metadata(512) after add_group (equal, no-op) =====\n");
 
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
+  oar_t *oar = NULL;
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
-    oar_destroy(oar);
+  if (create_binaural_oar_with_element(&oar, &out_channels, &input_data) != 0)
     return -1;
-  }
 
   int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
                                              TEST_SAMPLES_PER_CHANNEL);
@@ -239,32 +451,22 @@ static int test_set_metadata_equal_after_add_group() {
   }
 
   oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-  if (!output.data) {
+  if (alloc_output_block(out_channels, &output) != 0) {
     free(input_data);
     oar_destroy(oar);
     return -1;
   }
-  memset(output.data, 0,
-         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
 
-  ret = oar_render(oar, &output);
+  int result = 0;
+  if (render_and_check_non_silent(oar, &output, "TC2") != 0) result = -1;
 
   free(input_data);
   free(output.data);
   oar_destroy(oar);
 
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
-    return -1;
-  }
-
-  printf("PASS: set_metadata(512) + render succeeded.\n");
-  return 0;
+  if (result == 0)
+    printf("PASS: set_metadata(512) + render succeeded (non-silent).\n");
+  return result;
 }
 
 /* TC3: set_metadata(32) with stereo layout — should succeed */
@@ -282,7 +484,7 @@ static int test_set_metadata_stereo() {
 
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -312,16 +514,30 @@ static int test_set_metadata_stereo() {
 
   ret = oar_render(oar, &output);
 
+  if (ret != 0) {
+    fprintf(stderr, "FAIL: oar_render on stereo returned %d\n", ret);
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  if (!is_output_non_silent(output.data, total_samples)) {
+    fprintf(
+        stderr,
+        "FAIL: output is silent after stereo + set_metadata(32) + render.\n");
+    free(input_data);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
   free(input_data);
   free(output.data);
   oar_destroy(oar);
 
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render on stereo returned %d\n", ret);
-    return -1;
-  }
-
-  printf("PASS: stereo + set_metadata(32) + render succeeded.\n");
+  printf("PASS: stereo + set_metadata(32) + render succeeded (non-silent).\n");
   return 0;
 }
 
@@ -349,7 +565,7 @@ static int test_set_metadata_before_add_group_binaural() {
 
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -414,7 +630,7 @@ static int test_default_no_set_metadata_binaural() {
 
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -528,7 +744,7 @@ static int test_multiple_set_metadata_before_add_group() {
 
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_and_data(oar, &out_channels, &input_data) != 0) {
+  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -698,8 +914,7 @@ static int test_stereo_varying_positions_sub_frame() {
 
   uint32_t out_channels = 0;
   float *input_data = NULL;
-  if (add_object_element_without_position(oar, &out_channels, &input_data) !=
-      0) {
+  if (add_object_element(oar, &out_channels, &input_data, 0) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -717,13 +932,37 @@ static int test_stereo_varying_positions_sub_frame() {
   oar_metadata_t *meta_right =
       create_position_metadata(pos_right, TEST_SAMPLES_PER_CHANNEL / 2);
 
-  if (meta_left) {
-    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_left);
+  if (!meta_left || !meta_right) {
+    fprintf(stderr, "FAIL: create_position_metadata returned NULL.\n");
     free(meta_left);
-  }
-  if (meta_right) {
-    oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_right);
     free(meta_right);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_left);
+  free(meta_left);
+
+  if (ret != 0) {
+    fprintf(stderr,
+            "FAIL: oar_update_audio_element_metadata (left) returned %d.\n",
+            ret);
+    free(meta_right);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_right);
+  free(meta_right);
+  if (ret != 0) {
+    fprintf(stderr,
+            "FAIL: oar_update_audio_element_metadata (right) returned %d.\n",
+            ret);
+    free(input_data);
+    oar_destroy(oar);
+    return -1;
   }
 
   oar_audio_block_t output;
@@ -739,7 +978,6 @@ static int test_stereo_varying_positions_sub_frame() {
   }
 
   ret = oar_render(oar, &output);
-
   if (ret != 0) {
     fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
     free(input_data);
@@ -750,6 +988,7 @@ static int test_stereo_varying_positions_sub_frame() {
 
   /* Verify: left channel first half energy > second half, right channel vice
    * versa */
+
   uint32_t half = TEST_SAMPLES_PER_CHANNEL / 2;
   float left_first_half = 0.0f, left_second_half = 0.0f;
   float right_first_half = 0.0f, right_second_half = 0.0f;
@@ -785,28 +1024,521 @@ static int test_stereo_varying_positions_sub_frame() {
   return 0;
 }
 
-/* Test function table for child-process dispatch. */
-typedef int (*test_fn_t)(void);
-static test_fn_t g_test_table[] = {
-    test_set_metadata_after_add_group_binaural,  /* 0  TC1 */
-    test_set_metadata_equal_after_add_group,     /* 1  TC2 */
-    test_set_metadata_stereo,                    /* 2  TC3 */
-    test_set_metadata_before_add_group_binaural, /* 3  TC4 */
-    test_default_no_set_metadata_binaural,       /* 4  TC5 */
-    test_invalid_parameters,                     /* 5  TC6 */
-    test_multiple_set_metadata_before_add_group, /* 6  TC7 */
-    test_binaural_non_divisor_accepted,          /* 7  TC8 */
-    test_zero_samples_rejected,                  /* 8  TC9 */
-    test_exceeds_frame_rejected,                 /* 9  TC10 */
-    test_stereo_non_divisor_accepted,            /* 10 TC11 */
-    test_stereo_varying_positions_sub_frame,     /* 11 TC12 */
-};
-#define NUM_TESTS (int)(sizeof(g_test_table) / sizeof(g_test_table[0]))
+/* TC13: binaural, mirrored positions (±80°) → outputs differ + ILD flips.
+ *
+ * Primary assertion: two renders of identical input at mirrored azimuths must
+ * differ. If object positions never reach OBR, both render at the creation
+ * default (front-center) and the outputs are bit-identical, regardless of the
+ * HRIR set. Secondary assertion: the interaural energy asymmetry must follow
+ * the azimuth sign (positive azimuth = left, as in TC12). ILD magnitude
+ * accuracy is covered by OBR's own unit tests (GetBroadbandILD); only the
+ * sign is asserted here. */
+static int test_binaural_position_effect() {
+  printf("\n===== TC13: binaural mirrored positions (±80°) =====\n");
 
-static const char *g_test_names[] = {
-    "TC1", "TC2", "TC3", "TC4",  "TC5",  "TC6",
-    "TC7", "TC8", "TC9", "TC10", "TC11", "TC12",
+  uint32_t total = 2 * TEST_SAMPLES_PER_CHANNEL;
+  float *render_left = (float *)calloc(total, sizeof(float));
+  float *render_right = (float *)calloc(total, sizeof(float));
+  if (!render_left || !render_right) {
+    free(render_left);
+    free(render_right);
+    return -1;
+  }
+
+  /* Render the second frame so the measurement is past the onset. */
+  if (render_binaural_frames(TEST_SIDE_AZIMUTH, 2, render_left) != 0 ||
+      render_binaural_frames(-TEST_SIDE_AZIMUTH, 2, render_right) != 0) {
+    fprintf(stderr, "FAIL: binaural render failed.\n");
+    free(render_left);
+    free(render_right);
+    return -1;
+  }
+
+  int result = 0;
+  double sig = rms_of(render_left, total);
+  double diff = rms_diff(render_left, render_right, total);
+
+  if (sig < 1e-6) {
+    fprintf(stderr, "FAIL: binaural output is silent (rms=%g).\n", sig);
+    result = -1;
+  } else if (diff < TEST_MIN_RELATIVE_DIFF * sig) {
+    fprintf(stderr,
+            "FAIL: renders at +80° and -80° are (near-)identical "
+            "(diff rms=%g, signal rms=%g). Object positions are not being "
+            "delivered to OBR.\n",
+            diff, sig);
+    result = -1;
+  }
+
+  double e_l_pos = sum_abs(render_left, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_pos =
+      sum_abs(render_left + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+  double e_l_neg = sum_abs(render_right, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_neg = sum_abs(render_right + TEST_SAMPLES_PER_CHANNEL,
+                           TEST_SAMPLES_PER_CHANNEL);
+
+  if (e_l_pos <= TEST_ILD_RATIO * e_r_pos ||
+      e_r_neg <= TEST_ILD_RATIO * e_l_neg) {
+    fprintf(stderr,
+            "FAIL: interaural asymmetry does not follow azimuth sign.\n"
+            "  +80°: E_L=%.4f, E_R=%.4f (expected E_L dominant)\n"
+            "  -80°: E_L=%.4f, E_R=%.4f (expected E_R dominant)\n",
+            e_l_pos, e_r_pos, e_l_neg, e_r_neg);
+    result = -1;
+  }
+
+  if (result == 0) {
+    printf(
+        "PASS: mirrored positions render differently and ILD follows the "
+        "azimuth sign.\n");
+  }
+
+  free(render_left);
+  free(render_right);
+  return result;
+}
+
+/* TC14: binaural, position update between frames takes effect.
+ *
+ * OBR's buffer_size_per_channel is fixed at creation, so binaural position
+ * updates are frame-granular — but they must still be applied on the next
+ * frame. Render at +80°, update to -80°, and assert the interaural balance
+ * flips. The frame right after the update is skipped so any position
+ * crossfade inside OBR does not blur the measurement. */
+static int test_binaural_position_update_across_frames() {
+  printf("\n===== TC14: binaural position update across frames =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int result = -1;
+  float *frame1 = NULL;
+  float *frame3 = NULL;
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.data = NULL;
+
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
+    fprintf(stderr, "FAIL: element setup failed.\n");
+    goto done;
+  }
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  if (out_channels != 2) {
+    fprintf(stderr, "FAIL: expected 2 binaural output channels, got %u.\n",
+            out_channels);
+    goto done;
+  }
+
+  uint32_t total = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  frame1 = (float *)calloc(total, sizeof(float));
+  frame3 = (float *)calloc(total, sizeof(float));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data = (float *)calloc(total, sizeof(float));
+  if (!frame1 || !frame3 || !output.data) goto done;
+
+  /* Frame 1 at +80°, frames 2 and 3 at -80°; measure frames 1 and 3. */
+  float azimuths[3] = {TEST_SIDE_AZIMUTH, -TEST_SIDE_AZIMUTH,
+                       -TEST_SIDE_AZIMUTH};
+  for (int f = 0; f < 3; ++f) {
+    if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
+            0 ||
+        submit_position(oar, TEST_ELEMENT_ID, azimuths[f],
+                        TEST_SAMPLES_PER_CHANNEL) != 0) {
+      fprintf(stderr, "FAIL: data/metadata update failed on frame %d.\n",
+              f + 1);
+      goto done;
+    }
+    memset(output.data, 0, total * sizeof(float));
+    if (oar_render(oar, &output) != 0) {
+      fprintf(stderr, "FAIL: oar_render failed on frame %d.\n", f + 1);
+      goto done;
+    }
+    if (f == 0) memcpy(frame1, output.data, total * sizeof(float));
+    if (f == 2) memcpy(frame3, output.data, total * sizeof(float));
+  }
+
+  double sig = rms_of(frame1, total);
+  double diff = rms_diff(frame1, frame3, total);
+  double e_l_f1 = sum_abs(frame1, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_f1 =
+      sum_abs(frame1 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+  double e_l_f3 = sum_abs(frame3, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_f3 =
+      sum_abs(frame3 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+
+  if (sig < 1e-6) {
+    fprintf(stderr, "FAIL: binaural output is silent (rms=%g).\n", sig);
+  } else if (diff < TEST_MIN_RELATIVE_DIFF * sig) {
+    fprintf(stderr,
+            "FAIL: output did not change after the position update "
+            "(diff rms=%g, signal rms=%g).\n",
+            diff, sig);
+  } else if (e_l_f1 <= TEST_ILD_RATIO * e_r_f1 ||
+             e_r_f3 <= TEST_ILD_RATIO * e_l_f3) {
+    fprintf(stderr,
+            "FAIL: interaural balance did not flip after the update.\n"
+            "  frame1 (+80°): E_L=%.4f, E_R=%.4f\n"
+            "  frame3 (-80°): E_L=%.4f, E_R=%.4f\n",
+            e_l_f1, e_r_f1, e_l_f3, e_r_f3);
+  } else {
+    printf("PASS: position update applied on a subsequent frame.\n");
+    result = 0;
+  }
+
+done:
+  free(frame1);
+  free(frame3);
+  free(output.data);
+  oar_destroy(oar);
+  return result;
+}
+
+/* TC15: binaural, input block smaller than the configured frame must be
+ * rejected by oar_update_audio_element_data — not fed to OBR, whose
+ * ABSL_CHECK_EQ on the buffer size aborts the whole process. */
+static int test_undersized_block_rejected() {
+  printf("\n===== TC15: undersized input block rejected =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
+  if (!output.data) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
+  if (ret == 0) {
+    fprintf(stderr,
+            "FAIL: %u-sample block accepted with samples_per_channel=%u. "
+            "Rendering to demonstrate the failure mode (expect an abort in "
+            "ObrImpl::Process)...\n",
+            TEST_SAMPLES_PER_CHANNEL / 2, TEST_SAMPLES_PER_CHANNEL);
+    fflush(stderr);
+    oar_render(oar, &output);
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+  printf("  undersized block: returned %d (expected error) OK\n", ret);
+
+  /* The renderer must remain usable after the rejection. */
+  if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
+          0 ||
+      oar_render(oar, &output) != 0) {
+    fprintf(stderr, "FAIL: renderer unusable after rejected block.\n");
+    free(output.data);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf("PASS: undersized block rejected; renderer still renders.\n");
+  free(output.data);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC16: mismatched block sizes across two elements must be rejected. If both
+ * submissions are accepted, add_data memcpys the second element's larger
+ * block with the first block's stride/allocation — a heap buffer overflow
+ * (deterministic under ASan; here detected via the return codes). */
+static int test_mismatched_blocks_across_elements() {
+  printf("\n===== TC16: mismatched blocks across elements rejected =====\n");
+
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0 ||
+      add_object_element_to_group(oar, gid, TEST_ELEMENT_ID_2) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret_a =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
+  int ret_b =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID_2, TEST_SAMPLES_PER_CHANNEL);
+
+  if (ret_a == 0 && ret_b == 0) {
+    fprintf(stderr,
+            "FAIL: mismatched block sizes (%u then %u) both accepted — the "
+            "second memcpy in add_data overruns the staging buffer sized for "
+            "the first block.\n",
+            TEST_SAMPLES_PER_CHANNEL / 2, TEST_SAMPLES_PER_CHANNEL);
+    oar_destroy(oar);
+    return -1;
+  }
+
+  printf("PASS: mismatched block sizes rejected (first: %d, second: %d).\n",
+         ret_a, ret_b);
+  oar_destroy(oar);
+  return 0;
+}
+
+/* TC17 helper: create a binaural renderer with two object-based elements,
+ * where element 1 has num_objects=1 and element 2 has num_objects=2. This
+ * simultaneously exercises the multi-element multiplexing path
+ * (channel_start_index interleaving, apply_frame_positions per-element) and
+ * the multi-object path (polar_positions[1], dual-object metadata_update).
+ * Submit data and positions for both, render two frames, and copy the last
+ * frame into `out` (2 * TEST_SAMPLES_PER_CHANNEL floats, planar).
+ *
+ * az1: azimuth for element 1 (single object).
+ * az2_obj1, az2_obj2: azimuths for element 2's two objects. */
+static int render_multi_element_multi_object(float az1, float az2_obj1,
+                                             float az2_obj2, float *out) {
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  config.sampling_rate = TEST_SAMPLING_RATE;
+
+  oar_t *oar = oar_create(&config);
+  if (!oar) return -1;
+
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0 ||
+      add_object_element_to_group_n(oar, gid, TEST_ELEMENT_ID_2, 2) != 0) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  if (out_channels != 2) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  oar_audio_block_t output;
+  memset(&output, 0, sizeof(output));
+  output.channels = out_channels;
+  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
+  output.data =
+      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
+  if (!output.data) {
+    oar_destroy(oar);
+    return -1;
+  }
+
+  int ret = -1;
+  /* Submit data and positions for both elements, then render. */
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
+        0)
+      goto done;
+    if (submit_stimulus_block(oar, TEST_ELEMENT_ID_2,
+                              TEST_SAMPLES_PER_CHANNEL) != 0)
+      goto done;
+    if (submit_position(oar, TEST_ELEMENT_ID, az1, TEST_SAMPLES_PER_CHANNEL) !=
+        0)
+      goto done;
+    if (submit_position_dual(oar, TEST_ELEMENT_ID_2, az2_obj1, az2_obj2,
+                             TEST_SAMPLES_PER_CHANNEL) != 0)
+      goto done;
+    memset(output.data, 0,
+           out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+    if (oar_render(oar, &output) != 0) goto done;
+  }
+
+  memcpy(out, output.data,
+         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
+  ret = 0;
+
+done:
+  free(output.data);
+  oar_destroy(oar);
+  return ret;
+}
+
+/* TC17: binaural, multi-element + multi-object rendering.
+ *
+ * audio_elements_renderer (plural) multiplexes multiple object-based elements
+ * into a single OBR instance. This TC uses two elements: element 1 has
+ * num_objects=1, element 2 has num_objects=2. This simultaneously covers:
+ *   - Multi-element: channel_start_index interleaving, apply_frame_positions
+ *     per-element traversal.
+ *   - Multi-object: polar_positions[1] path, dual-object metadata_update
+ *     via submit_position_dual.
+ *
+ * Verification:
+ *   1. Render succeeds and output is non-silent.
+ *   2. When all objects are on the same side (element 1 at +80°, element 2's
+ *      two objects both at +80°), the ILD is stronger than when element 2's
+ *      objects are split (one at +80°, one at -80°), confirming that both
+ *      objects within the num_objects=2 element reach OBR independently.
+ *   3. The two renders differ, proving the multi-object positions affect
+ *      output. */
+static int test_multi_element_rendering() {
+  printf("\n===== TC17: multi-element + multi-object rendering =====\n");
+
+  uint32_t total = 2 * TEST_SAMPLES_PER_CHANNEL;
+  float *render_opposite = (float *)calloc(total, sizeof(float));
+  float *render_same = (float *)calloc(total, sizeof(float));
+  if (!render_opposite || !render_same) {
+    free(render_opposite);
+    free(render_same);
+    return -1;
+  }
+
+  /* Render with split objects: element 1 at +80°, element 2's two objects
+   * at +80° and -80°. Element 2's objects span both sides, weakening ILD. */
+  if (render_multi_element_multi_object(TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH,
+                                        -TEST_SIDE_AZIMUTH,
+                                        render_opposite) != 0) {
+    fprintf(stderr, "FAIL: multi-element render (split) failed.\n");
+    free(render_opposite);
+    free(render_same);
+    return -1;
+  }
+
+  /* Render with all objects on same side: element 1 at +80°, element 2's
+   * two objects both at +80°. All three objects on the left → strong ILD. */
+  if (render_multi_element_multi_object(TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH,
+                                        TEST_SIDE_AZIMUTH, render_same) != 0) {
+    fprintf(stderr, "FAIL: multi-element render (same) failed.\n");
+    free(render_opposite);
+    free(render_same);
+    return -1;
+  }
+
+  int result = 0;
+
+  /* 1. Both renders must be non-silent. */
+  double sig_opposite = rms_of(render_opposite, total);
+  double sig_same = rms_of(render_same, total);
+  if (sig_opposite < 1e-6) {
+    fprintf(stderr, "FAIL: opposite-azimuth output is silent (rms=%g).\n",
+            sig_opposite);
+    result = -1;
+  } else if (sig_same < 1e-6) {
+    fprintf(stderr, "FAIL: same-azimuth output is silent (rms=%g).\n",
+            sig_same);
+    result = -1;
+  }
+
+  /* 2. When both elements are at +80°, the left ear should be strongly
+   *    dominant (both objects on the left). When they are at opposite
+   *    azimuths, the ILD should be weaker (one object each side).
+   *    Verify: |E_L - E_R| / (E_L + E_R) is larger for same-azimuth. */
+  double e_l_same = sum_abs(render_same, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_same =
+      sum_abs(render_same + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+  double e_l_opp = sum_abs(render_opposite, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_opp = sum_abs(render_opposite + TEST_SAMPLES_PER_CHANNEL,
+                           TEST_SAMPLES_PER_CHANNEL);
+
+  double ild_same = fabs(e_l_same - e_r_same) / (e_l_same + e_r_same + 1e-12);
+  double ild_opp = fabs(e_l_opp - e_r_opp) / (e_l_opp + e_r_opp + 1e-12);
+
+  if (ild_same <= ild_opp) {
+    fprintf(stderr,
+            "FAIL: ILD not stronger when both elements share azimuth.\n"
+            "  same azimuth (+80,+80): ILD=%.4f (E_L=%.4f, E_R=%.4f)\n"
+            "  opposite (+80,-80):     ILD=%.4f (E_L=%.4f, E_R=%.4f)\n"
+            "  Expected same-azimuth ILD > opposite-azimuth ILD, confirming\n"
+            "  both elements' positions reach OBR independently.\n",
+            ild_same, e_l_same, e_r_same, ild_opp, e_l_opp, e_r_opp);
+    result = -1;
+  }
+
+  /* 3. The two renders must differ (proves element 2's data affects output). */
+  double diff = rms_diff(render_opposite, render_same, total);
+  if (diff < TEST_MIN_RELATIVE_DIFF * sig_same) {
+    fprintf(stderr,
+            "FAIL: opposite-azimuth and same-azimuth renders are "
+            "near-identical (diff rms=%g, signal rms=%g). Element 2's data "
+            "or position may not be reaching OBR.\n",
+            diff, sig_same);
+    result = -1;
+  }
+
+  if (result == 0) {
+    printf(
+        "PASS: two elements rendered simultaneously with independent "
+        "positions.\n");
+  }
+
+  free(render_opposite);
+  free(render_same);
+  return result;
+}
+
+/* Unified test table for child-process dispatch. Each entry combines the
+ * short name, human-readable description, and test function in one place,
+ * eliminating the need to keep separate arrays in sync. */
+typedef int (*test_fn_t)(void);
+typedef struct {
+  const char *name;
+  const char *description;
+  test_fn_t fn;
+} test_entry_t;
+
+static test_entry_t g_tests[] = {
+    {"TC1", "set_metadata after add_group",
+     test_set_metadata_after_add_group_binaural},
+    {"TC2", "set_metadata equal, no-op",
+     test_set_metadata_equal_after_add_group},
+    {"TC3", "stereo + set_metadata", test_set_metadata_stereo},
+    {"TC4", "set_metadata before add_group",
+     test_set_metadata_before_add_group_binaural},
+    {"TC5", "default, no set_metadata", test_default_no_set_metadata_binaural},
+    {"TC6", "invalid parameters", test_invalid_parameters},
+    {"TC7", "multiple set_metadata",
+     test_multiple_set_metadata_before_add_group},
+    {"TC8", "binaural non-divisor", test_binaural_non_divisor_accepted},
+    {"TC9", "zero samples", test_zero_samples_rejected},
+    {"TC10", "samples > frame", test_exceeds_frame_rejected},
+    {"TC11", "stereo non-divisor", test_stereo_non_divisor_accepted},
+    {"TC12", "stereo varying positions",
+     test_stereo_varying_positions_sub_frame},
+    {"TC13", "binaural mirrored positions", test_binaural_position_effect},
+    {"TC14", "binaural update across frames",
+     test_binaural_position_update_across_frames},
+    {"TC15", "undersized block rejected", test_undersized_block_rejected},
+    {"TC16", "mismatched blocks rejected",
+     test_mismatched_blocks_across_elements},
+    {"TC17", "multi-element + multi-object rendering",
+     test_multi_element_rendering},
 };
+
+#define NUM_TESTS (int)(sizeof(g_tests) / sizeof(g_tests[0]))
 
 /* Run a test function in a separate child process so that a crash
  * does not prevent subsequent tests from running.
@@ -816,10 +1548,11 @@ static const char *g_test_names[] = {
  * with "--child <index>" to run a single test in a child process.
  * Both paths provide identical crash isolation behaviour. */
 static int run_test_in_child(int test_index) {
-  const char *name = g_test_names[test_index];
+  const char *name = g_tests[test_index].name;
 
 #ifndef _WIN32
-  test_fn_t test_fn = g_test_table[test_index];
+  test_fn_t test_fn = g_tests[test_index].fn;
+
   fflush(stdout);
   fflush(stderr);
 
@@ -869,22 +1602,37 @@ static int run_test_in_child(int test_index) {
 
   snprintf(index_str, sizeof(index_str), "%d", test_index);
 
-  int exit_code =
-      _spawnl(_P_WAIT, exe_path, exe_path, "--child", index_str, NULL);
+  /* Quote the exe path for argv[0] to handle paths containing spaces.
+   * _spawnl's cmdname (first exe_path) is used to locate the executable
+   * and is not parsed as a command line, so it doesn't need quoting.
+   * argv[0] (second exe_path) is written into the command line string and
+   * needs quoting for non-MSVC CRTs that don't auto-quote argv[0]. */
+  char quoted_path[1028];
+  snprintf(quoted_path, sizeof(quoted_path), "\"%s\"", exe_path);
 
-  if (exit_code == 0) {
+  errno = 0;
+  int exit_code =
+      _spawnl(_P_WAIT, exe_path, quoted_path, "--child", index_str, NULL);
+
+  if (exit_code == -1 && errno != 0) {
+    /* _spawnl failed to launch the child process (not a child exit code).
+     * Process exit codes are 8-bit unsigned (0-255), so -1 uniquely
+     * identifies spawn failure, but checking errno makes this explicit
+     * and portable across CRT implementations. */
+    fprintf(stderr, "[%s] FAILED: spawn error (errno %d: %s)\n", name, errno,
+            strerror(errno));
+    return -1;
+  } else if (exit_code == 0) {
     printf("[%s] PASSED (exit 0)\n", name);
     return 0;
-  } else if (exit_code == -1) {
-    printf("[%s] FAILED: spawn error\n", name);
-    return -1;
   } else {
-    /* On Windows, a crash typically yields exit code 3
-     * (STATUS_ACCESS_VIOLATION) or similar non-zero codes. We treat any
-     * non-zero exit as failure. */
+    /* Non-zero exit: test failure or crash.
+     * On Windows, a crash typically yields exit code 3
+     * (STATUS_ACCESS_VIOLATION) or similar non-zero codes. */
     printf("[%s] FAILED/CRASHED (exit %d)\n", name, exit_code);
     return -1;
   }
+
 #endif
 }
 
@@ -896,7 +1644,8 @@ int main(int argc, char *argv[]) {
     if (index < 0 || index >= NUM_TESTS) {
       return -1;
     }
-    int ret = g_test_table[index]();
+    int ret = g_tests[index].fn();
+
     fflush(stdout);
     fflush(stderr);
     return ret;
@@ -913,37 +1662,17 @@ int main(int argc, char *argv[]) {
   int tc_results[NUM_TESTS];
 
   for (int i = 0; i < NUM_TESTS; i++) {
-    printf("\n--- Running %s ---\n", g_test_names[i]);
+    printf("\n--- Running %s ---\n", g_tests[i].name);
     tc_results[i] = run_test_in_child(i);
     result |= (tc_results[i] != 0) ? 1 : 0;
   }
 
   printf("\n========================================\n");
   printf("Test Summary:\n");
-  printf("  TC1 (set_metadata after add_group):   %s\n",
-         tc_results[0] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC2 (set_metadata equal, no-op):     %s\n",
-         tc_results[1] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC3 (stereo + set_metadata):          %s\n",
-         tc_results[2] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC4 (set_metadata before add_group):  %s\n",
-         tc_results[3] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC5 (default, no set_metadata):       %s\n",
-         tc_results[4] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC6 (invalid parameters):             %s\n",
-         tc_results[5] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC7 (multiple set_metadata):          %s\n",
-         tc_results[6] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC8 (binaural non-divisor):           %s\n",
-         tc_results[7] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC9 (zero samples):                  %s\n",
-         tc_results[8] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC10 (samples > frame):               %s\n",
-         tc_results[9] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC11 (stereo non-divisor):            %s\n",
-         tc_results[10] == 0 ? "PASSED" : "FAILED/CRASHED");
-  printf("  TC12 (stereo varying positions):      %s\n",
-         tc_results[11] == 0 ? "PASSED" : "FAILED/CRASHED");
+  for (int i = 0; i < NUM_TESTS; i++) {
+    printf("  %s (%s): %s\n", g_tests[i].name, g_tests[i].description,
+           tc_results[i] == 0 ? "PASSED" : "FAILED/CRASHED");
+  }
   printf("========================================\n");
 
   if (result == 0) {

--- a/tests/examples/test_metadata_unit_processing.c
+++ b/tests/examples/test_metadata_unit_processing.c
@@ -1614,11 +1614,10 @@ static int run_test_in_child(int test_index) {
   int exit_code =
       _spawnl(_P_WAIT, exe_path, quoted_path, "--child", index_str, NULL);
 
-  if (exit_code == -1 && errno != 0) {
-    /* _spawnl failed to launch the child process (not a child exit code).
-     * Process exit codes are 8-bit unsigned (0-255), so -1 uniquely
-     * identifies spawn failure, but checking errno makes this explicit
-     * and portable across CRT implementations. */
+  if (exit_code == -1) {
+    /* The child process never exits with -1 (see main(): failures are mapped
+     * to exit code 1), so -1 unambiguously means _spawnl itself failed to
+     * launch the child.  errno provides additional diagnostic detail. */
     fprintf(stderr, "[%s] FAILED: spawn error (errno %d: %s)\n", name, errno,
             strerror(errno));
     return -1;
@@ -1642,13 +1641,16 @@ int main(int argc, char *argv[]) {
   if (argc >= 3 && strcmp(argv[1], "--child") == 0) {
     int index = atoi(argv[2]);
     if (index < 0 || index >= NUM_TESTS) {
-      return -1;
+      return 2; /* sentinel: invalid index (distinct from test failure) */
     }
     int ret = g_tests[index].fn();
 
     fflush(stdout);
     fflush(stderr);
-    return ret;
+    /* Map -1 (test failure) to exit code 1 so that -1 from _spawnl uniquely
+     * identifies a spawn failure rather than colliding with the child's own
+     * failure return. */
+    return (ret != 0) ? 1 : 0;
   }
 
   printf("========================================\n");


### PR DESCRIPTION
When oar_set_metadata_unit_to_process was called with a sub-frame size smaller than config.samples_per_channel for binaural rendering, OBR crashed because its internal buffer_size_per_channel (fixed at creation time) did not match the sub-frame input buffer size, triggering an ABSL_CHECK_EQ assertion failure in ObrImpl::Process.

Changes:
- Fix binaural OBR to always render the full frame using config.samples_per_channel, bypassing sub-frame position updates since OBR fixes buffer_size_per_channel at creation time (audio_elements_renderer.c)
- Add input validation in oar_set_metadata_unit_to_process to reject samples == 0 or samples > config.samples_per_channel (oar.c)
- Update API documentation to clarify that the samples parameter has no effect on binaural rendering (oar.h)
- Add test_metadata_unit_processing.c with 12 test cases covering binaural/stereo sub-frame rendering, invalid parameters, and crash isolation

Fixes #29