### PR TITLE
Add audio element removal support with binaural renderer lifecycle management

### DIFF
--- a/include/oar.h
+++ b/include/oar.h
@@ -156,9 +156,11 @@ void oar_destroy(oar_t *oar);
 /**
  * @brief     Add an audio group
  * @param     [in] oar : OAR object
- * @return    Group ID (0-1) on success, negative error code on failure
- *            -1 for invalid parameters, -12 for memory allocation failure,
- *            -16 if maximum number of groups (2) already reached
+ * @return    Group ID (0-1) on success, negative error code on failure:
+ *            ck_oar_error_inval (-22) for invalid parameters,
+ *            ck_oar_error_busy (-16) if max groups (2) reached,
+ *            ck_oar_error_nomem (-12) for memory allocation failure,
+ *            ck_oar_error_notsup (-95) if binaural renderer creation fails
  */
 int oar_add_audio_group(oar_t *oar);
 
@@ -168,8 +170,10 @@ int oar_add_audio_group(oar_t *oar);
  * @param     [in] gid : Group ID where the element will be added
  * @param     [in] id : Unique element id (must be unique across all groups)
  * @param     [in] config : Element configuration
- * @return    0 on success, -1 for invalid parameters, -12 for memory allocation
- *            failure.
+ * @return    ck_oar_ok (0) on success, negative error code on failure:
+ *            ck_oar_error_inval (-22) for invalid parameters or non-existent
+ *            group, ck_oar_error_busy (-16) if element ID already exists,
+ *            ck_oar_error_nomem (-12) for memory allocation failure
  */
 int oar_add_audio_element(oar_t *oar, uint32_t gid, uint32_t id,
                           const oar_audio_element_config_t *config);
@@ -178,7 +182,17 @@ int oar_add_audio_element(oar_t *oar, uint32_t gid, uint32_t id,
  * @brief     Remove an audio element
  * @param     [in] oar : OAR object
  * @param     [in] id : Unique element id (searched across all groups)
- * @return    0 on success, -1 for invalid parameters or if ID doesn't exist
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters or non-existent ID. ck_oar_error_notsup (-95) for
+ *            unsupported removal order
+ * @note      For binaural (multi-element) renderers, only the specified element
+ *            is removed — the renderer itself is retained and its lifecycle is
+ *            tied to the audio group. For single-element renderers, the entire
+ *            renderer is destroyed
+ * @note      The binaural renderer library (OBR) only supports LIFO (last-in,
+ *            first-out) element removal. Attempting to remove a non-last
+ *            element will return ck_oar_error_notsup and the element remains
+ *            active. Rendering is unaffected by a failed removal
  */
 int oar_remove_audio_element(oar_t *oar, uint32_t id);
 
@@ -187,7 +201,8 @@ int oar_remove_audio_element(oar_t *oar, uint32_t id);
  * @param     [in] oar : OAR object
  * @param     [in] id : Unique element id (searched across all groups)
  * @param     [in] metadata : Metadata to update
- * @return    0 on success, -1 for invalid parameters or if ID doesn't exist
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters or non-existent ID
  */
 int oar_update_audio_element_metadata(oar_t *oar, uint32_t id,
                                       const oar_metadata_t *metadata);
@@ -197,7 +212,8 @@ int oar_update_audio_element_metadata(oar_t *oar, uint32_t id,
  * @param     [in] oar : OAR object
  * @param     [in] id : Unique element id (searched across all groups)
  * @param     [in] data : Audio data in planar format
- * @return    0 on success, -1 for invalid parameters or if ID doesn't exist
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters or non-existent ID
  */
 int oar_update_audio_element_data(oar_t *oar, uint32_t id,
                                   oar_audio_block_t *data);
@@ -213,8 +229,9 @@ int oar_update_audio_element_data(oar_t *oar, uint32_t id,
  * @param     [in] type : Metadata type to configure (currently only
  *                        ck_metadata_object_positions supported)
  * @param     [in] samples : Number of samples to process as a unit
- * @return    0 on success, -1 for invalid parameters, -18 for unsupported
- *            metadata type
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters, ck_oar_error_notsup (-95) for unsupported metadata
+ *            type
  * @note      Currently only ck_metadata_object_positions is supported.
  *            samples must be in range (0, samples_per_channel].
  *            For non-binaural rendering, this controls sub-frame position
@@ -234,8 +251,12 @@ int oar_set_metadata_unit_to_process(oar_t *oar, oar_metadata_type_t type,
  * @param     [in] gid : Group ID to update metadata for
  * @param     [in] metadata : Metadata to update (only ck_metadata_gain type
  *                            supported)
- * @return    0 on success, -1 for invalid parameters or if group ID doesn't
- *            exist
+ * @return    ck_oar_ok (0) on success, negative error code on failure:
+ *            ck_oar_error_inval (-22) for invalid parameters or non-existent
+ *            group ID, ck_oar_error_nomem (-12) for memory allocation failure,
+ *            ck_oar_error_busy (-16) if head rotation is provided without head
+ *            tracking enabled, ck_oar_error_notsup (-95) for unsupported
+ *            metadata type
  */
 int oar_update_metadata(oar_t *oar, uint32_t gid,
                         const oar_metadata_t *metadata);
@@ -244,7 +265,9 @@ int oar_update_metadata(oar_t *oar, uint32_t gid,
  * @brief     Perform rendering
  * @param     [in] oar : OAR object
  * @param     [out] output : Output audio data in planar format.
- * @return    0 on success, -1 for invalid parameters
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters (including channel/sample mismatch or no audio groups),
+ *            ck_oar_error_nomem (-12) for memory allocation failure
  * @note      Renders all audio groups. For single group, uses zero-copy
  *            optimization. For multiple groups, mixes all group outputs.
  */
@@ -254,7 +277,8 @@ int oar_render(oar_t *oar, oar_audio_block_t *output);
  * @brief     Enable/disable loudness processor
  * @param     [in] oar : OAR object
  * @param     [in] enable : 1 to enable, 0 to disable
- * @return    0 on success, -1 for invalid parameters
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters
  * @note      When enabled, applies group-specific loudness gain during
  *            rendering
  */
@@ -266,8 +290,8 @@ int oar_enable_loudness_processor(oar_t *oar, int enable);
  * @param     [in] gid : Group ID to set loudness for
  * @param     [in] loudness : current loudness in dB
  * @param     [in] target_loudness : Target loudness in dB
- * @return    0 on success, -1 for invalid parameters or if group ID doesn't
- *            exist
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters or non-existent group ID
  */
 int oar_set_loudness(oar_t *oar, uint32_t gid, float loudness,
                      float target_loudness);
@@ -276,7 +300,8 @@ int oar_set_loudness(oar_t *oar, uint32_t gid, float loudness,
  * @brief     Enable/disable limiter
  * @param     [in] oar : OAR object
  * @param     [in] enable : 1 to enable, 0 to disable
- * @return    0 on success, -1 for invalid parameters
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters
  */
 int oar_enable_limiter(oar_t *oar, int enable);
 
@@ -291,7 +316,9 @@ int oar_enable_limiter(oar_t *oar, int enable);
  *
  * @param     [in] oar : OAR object
  * @param     [in] enable : 1 to enable, 0 to disable
- * @return    0 on success, -1 for invalid parameters
+ * @return    ck_oar_ok (0) on success, ck_oar_error_inval (-22) for invalid
+ *            parameters, ck_oar_error_notsup (-95) if target layout is not
+ *            binaural
  * @note      Applies to all audio elements across all groups. Only supported
  *            for binaural layout.
  */

--- a/src/oar.c
+++ b/src/oar.c
@@ -89,8 +89,6 @@ static int _find_group_id(value_wrap_t item, value_wrap_t key) {
   return group->id == key.u32 ? 1 : 0;
 }
 
-static void _audio_element_delete(audio_renderer_base_t *renderer) {}
-
 static int _find_element_id(value_wrap_t item, value_wrap_t key) {
   audio_renderer_base_t *renderer = def_value_wrap_ptr(&item);
 
@@ -344,8 +342,25 @@ int oar_remove_audio_element(oar_t *oar, uint32_t id) {
     index = vector_find(group->renderers, def_value_wrap_instance_u32(id),
                         _find_element_id, &v);
     if (index >= 0) {
-      vector_remove(group->renderers, index,
-                    def_default_free_ptr(_audio_element_delete));
+      audio_renderer_base_t *renderer =
+          def_value_wrap_type_ptr(audio_renderer_base_t, &v);
+
+      if (renderer->ctx.in == ck_ri_multi_ids) {
+        /* Binaural (multi-element) renderer: remove only the single element.
+         * The renderer itself is not destroyed here — its lifecycle is tied
+         * to the audio group (created in oar_add_audio_group, destroyed in
+         * _audio_group_delete). Keeping the empty renderer allows subsequent
+         * oar_add_audio_element calls to reuse it. */
+        if (renderer->impl && renderer->impl->remove_element) {
+          int ret = renderer->impl->remove_element(renderer, id);
+          if (ret != ck_oar_ok) return ret;
+        }
+      } else {
+        /* Single-element renderer: remove and destroy entirely */
+        vector_remove(group->renderers, index,
+                      def_default_free_ptr(audio_renderer_delete));
+      }
+
       return ck_oar_ok;
     }
   }

--- a/src/oar.c
+++ b/src/oar.c
@@ -354,6 +354,8 @@ int oar_remove_audio_element(oar_t *oar, uint32_t id) {
         if (renderer->impl && renderer->impl->remove_element) {
           int ret = renderer->impl->remove_element(renderer, id);
           if (ret != ck_oar_ok) return ret;
+        } else {
+          return ck_oar_error_notsup;
         }
       } else {
         /* Single-element renderer: remove and destroy entirely */
@@ -666,10 +668,10 @@ uint32_t oar_get_number_of_audio_element_channels(oar_t *oar, uint32_t id) {
                     _find_element_id, &v) >= 0) {
       audio_renderer_base_t *renderer = def_value_wrap_ptr(&v);
       // Call function through impl pointer
-      if (renderer->impl && renderer->impl->get_element_channels)
-        return renderer->impl->get_element_channels(renderer, id);
-      else if (renderer->impl && renderer->impl->get_channels)
-        return renderer->impl->get_channels(renderer);
+      if (renderer->impl && renderer->impl->get_element_channel_count)
+        return renderer->impl->get_element_channel_count(renderer, id);
+      else if (renderer->impl && renderer->impl->get_channel_count)
+        return renderer->impl->get_channel_count(renderer);
     }
   }
 
@@ -689,7 +691,13 @@ uint32_t oar_get_number_of_audio_elements(oar_t *oar) {
 
   for (i = 0; i < vector_size(oar->groups); i++) {
     audio_group_t *group = def_value_wrap_ptr(vector_at(oar->groups, i));
-    total_count += vector_size(group->renderers);
+
+    for (int j = 0; j < vector_size(group->renderers); j++) {
+      audio_renderer_base_t *renderer =
+          def_value_wrap_ptr(vector_at(group->renderers, j));
+      if (renderer && renderer->impl && renderer->impl->get_element_count)
+        total_count += renderer->impl->get_element_count(renderer);
+    }
   }
 
   return total_count;

--- a/src/renderer/audio_element_renderer.c
+++ b/src/renderer/audio_element_renderer.c
@@ -163,7 +163,7 @@ static int _sub_frames_apply_positions(audio_element_renderer_t *renderer,
 
 // Public API functions
 static void audio_element_renderer_delete(audio_renderer_base_t *base);
-static uint32_t audio_element_renderer_get_channels(
+static uint32_t audio_element_renderer_get_channel_count(
     audio_renderer_base_t *base);
 
 audio_element_renderer_t *audio_element_renderer_new(
@@ -208,7 +208,8 @@ audio_element_renderer_t *audio_element_renderer_new(
   self->base.metadata_samples_ref = metadata_samples_ref;
 
   info("Using self library %s for stream %u", self->base.lib->id, id);
-  self->base.block.channels = audio_element_renderer_get_channels(&self->base);
+  self->base.block.channels =
+      audio_element_renderer_get_channel_count(&self->base);
   self->base.block.samples_per_channel = oar_config->samples_per_channel;
   self->base.block.data = def_mallocz(
       float, self->base.block.channels * self->base.block.samples_per_channel);
@@ -395,7 +396,7 @@ int audio_element_renderer_apply_gains(audio_renderer_base_t *base,
   return ck_oar_ok;
 }
 
-uint32_t audio_element_renderer_get_channels(audio_renderer_base_t *base) {
+uint32_t audio_element_renderer_get_channel_count(audio_renderer_base_t *base) {
   audio_element_renderer_t *self = def_audio_element_renderer_ptr(base);
   switch (self->config.type) {
     case ck_channel_based:
@@ -457,6 +458,11 @@ void audio_element_renderer_metadatas_elapse(audio_renderer_base_t *base,
   }
 }
 
+static uint32_t audio_element_renderer_get_element_count(
+    audio_renderer_base_t *base) {
+  return 1;
+}
+
 // Wrapper function implementations
 audio_renderer_base_t *audio_element_renderer_create_wrapper(
     const oar_config_t *oar_config, uint32_t id,
@@ -477,7 +483,8 @@ audio_renderer_base_t *audio_element_renderer_create_wrapper(
         .set_element_head_locked =
             audio_element_renderer_set_element_head_locked,
         .set_head_rotation = audio_renderer_set_head_rotation,
-        .get_channels = audio_element_renderer_get_channels,
+        .get_channel_count = audio_element_renderer_get_channel_count,
+        .get_element_count = audio_element_renderer_get_element_count,
         .metadatas_elapse = audio_element_renderer_metadatas_elapse,
     };
 

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -246,10 +246,6 @@ int audio_elements_renderer_remove_element(audio_renderer_base_t *base,
     return ck_oar_error_inval;
   }
 
-  /* Notify the underlying renderer library to release per-element DSP
-   * resources.  If the library does not support removal (e.g., OBR only
-   * supports LIFO), abort the removal so that OAR and library state stay
-   * consistent.  The element remains functional and rendering is unaffected. */
   if (self->base.lib && self->base.lib->set_attribute) {
     uint32_t lib_index = ctx->index;
     int ret = self->base.lib->set_attribute(

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -283,6 +283,16 @@ int audio_elements_renderer_remove_element(audio_renderer_base_t *base,
   self->channels_count -= removed_channels;
   self->elements_updated = 1;
 
+  /* Free the staging buffer to prevent stale data from being rendered.
+   * The next add_data call will reallocate it with the updated channels_count.
+   */
+  if (self->base.block.data) {
+    def_free(self->base.block.data);
+    self->base.block.data = NULL;
+    self->base.block.channels = 0;
+    self->base.block.samples_per_channel = 0;
+  }
+
   info("Removed element %u from binaural renderer, remaining elements: %d",
        element_id, vector_size(self->elements));
 
@@ -487,19 +497,27 @@ int audio_elements_renderer_set_element_head_locked(audio_renderer_base_t *base,
   return ck_oar_error_notsup;
 }
 
-uint32_t audio_elements_renderer_get_channels(audio_renderer_base_t *base) {
+uint32_t audio_elements_renderer_get_channel_count(
+    audio_renderer_base_t *base) {
   audio_elements_renderer_t *self = def_audio_elements_renderer_ptr(base);
   return self->channels_count;
 }
 
-int audio_elements_renderer_get_element_channels(audio_renderer_base_t *base,
-                                                 uint32_t element_id) {
+uint32_t audio_elements_renderer_get_element_count(
+    audio_renderer_base_t *base) {
+  audio_elements_renderer_t *self = def_audio_elements_renderer_ptr(base);
+  if (!self || !self->elements) return 0;
+  return (uint32_t)vector_size(self->elements);
+}
+
+uint32_t audio_elements_renderer_get_element_channel_count(
+    audio_renderer_base_t *base, uint32_t element_id) {
   audio_elements_renderer_t *self = def_audio_elements_renderer_ptr(base);
   if (!self) return 0;
 
   audio_element_context_t *ctx = def_value_wrap_optional_type_ptr(
       audio_element_context_t, hash_map_get(self->element_map, element_id));
-  return ctx ? (int)rid_channels_count(ctx->rid) : 0;
+  return ctx ? rid_channels_count(ctx->rid) : 0;
 }
 
 void audio_elements_renderer_metadatas_elapse(audio_renderer_base_t *base,
@@ -558,8 +576,10 @@ audio_renderer_base_t *audio_elements_renderer_create_wrapper(
         .set_element_head_locked =
             audio_elements_renderer_set_element_head_locked,
         .set_head_rotation = audio_renderer_set_head_rotation,
-        .get_channels = audio_elements_renderer_get_channels,
-        .get_element_channels = audio_elements_renderer_get_element_channels,
+        .get_channel_count = audio_elements_renderer_get_channel_count,
+        .get_element_channel_count =
+            audio_elements_renderer_get_element_channel_count,
+        .get_element_count = audio_elements_renderer_get_element_count,
         .metadatas_elapse = audio_elements_renderer_metadatas_elapse,
     };
 

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -234,6 +234,61 @@ int audio_elements_renderer_add_element(
   return ret;
 }
 
+int audio_elements_renderer_remove_element(audio_renderer_base_t *base,
+                                           uint32_t element_id) {
+  audio_elements_renderer_t *self = def_audio_elements_renderer_ptr(base);
+  if (!self) return ck_oar_error_inval;
+
+  audio_element_context_t *ctx = def_value_wrap_optional_type_ptr(
+      audio_element_context_t, hash_map_get(self->element_map, element_id));
+  if (!ctx) {
+    warning("Element %u not found for removal", element_id);
+    return ck_oar_error_inval;
+  }
+
+  /* Notify the underlying renderer library to release per-element DSP
+   * resources.  If the library does not support removal (e.g., OBR only
+   * supports LIFO), abort the removal so that OAR and library state stay
+   * consistent.  The element remains functional and rendering is unaffected. */
+  if (self->base.lib && self->base.lib->set_attribute) {
+    uint32_t lib_index = ctx->index;
+    int ret = self->base.lib->set_attribute(
+        &self->base.ctx, ck_attribute_remove_element, &lib_index);
+    if (ret != ck_oar_ok) {
+      warning(
+          "Cannot remove element %u from renderer library (error %d). "
+          "Removal aborted; element remains active.",
+          element_id, ret);
+      return ret;
+    }
+  }
+
+  uint32_t removed_channels = rid_channels_count(ctx->rid);
+  uint32_t removed_index = ctx->index;
+
+  hash_map_remove(self->element_map, element_id);
+  vector_remove(self->elements, removed_index,
+                def_default_free_ptr(audio_element_context_delete));
+
+  /* Update indices and channel offsets for remaining elements */
+  for (int i = removed_index; i < vector_size(self->elements); i++) {
+    audio_element_context_t *remaining_ctx = def_value_wrap_type_ptr(
+        audio_element_context_t, vector_at(self->elements, i));
+    if (remaining_ctx) {
+      remaining_ctx->index = i;
+      remaining_ctx->channel_start_index -= removed_channels;
+    }
+  }
+
+  self->channels_count -= removed_channels;
+  self->elements_updated = 1;
+
+  info("Removed element %u from binaural renderer, remaining elements: %d",
+       element_id, vector_size(self->elements));
+
+  return ck_oar_ok;
+}
+
 int audio_elements_renderer_get_element_index(audio_renderer_base_t *base,
                                               uint32_t element_id) {
   audio_elements_renderer_t *self = def_audio_elements_renderer_ptr(base);
@@ -493,6 +548,7 @@ audio_renderer_base_t *audio_elements_renderer_create_wrapper(
         .destroy = audio_elements_renderer_delete,
         .get_element_index = audio_elements_renderer_get_element_index,
         .add_element = audio_elements_renderer_add_element,
+        .remove_element = audio_elements_renderer_remove_element,
         .update_element_metadata =
             audio_elements_renderer_update_element_metadata,
         .add_data = audio_elements_renderer_add_data,

--- a/src/renderer/audio_renderer_api.h
+++ b/src/renderer/audio_renderer_api.h
@@ -33,6 +33,9 @@ typedef int (*func_add_element_t)(audio_renderer_base_t *base,
                                   uint32_t element_id,
                                   const oar_audio_element_config_t *config);
 
+typedef int (*func_remove_element_t)(audio_renderer_base_t *base,
+                                     uint32_t element_id);
+
 typedef int (*func_get_element_index_t)(audio_renderer_base_t *base,
                                         uint32_t element_id);
 
@@ -70,6 +73,7 @@ typedef int (*func_get_element_channels_t)(audio_renderer_base_t *base,
 struct AudioRendererAPI {
   func_destroy_t destroy;
   func_add_element_t add_element;
+  func_remove_element_t remove_element;
   func_get_element_index_t get_element_index;
   func_update_element_metadata_t update_element_metadata;
   func_set_element_head_locked_t set_element_head_locked;

--- a/src/renderer/audio_renderer_api.h
+++ b/src/renderer/audio_renderer_api.h
@@ -61,13 +61,15 @@ typedef int (*func_set_element_head_locked_t)(audio_renderer_base_t *base,
 typedef int (*func_set_head_rotation_t)(audio_renderer_base_t *base,
                                         const quaternion_t *rotation);
 
-typedef uint32_t (*func_get_channels_t)(audio_renderer_base_t *base);
+typedef uint32_t (*func_get_channel_count_t)(audio_renderer_base_t *base);
 
 typedef void (*func_metadatas_elapse_t)(audio_renderer_base_t *base,
                                         uint32_t samples_per_channel);
 
-typedef int (*func_get_element_channels_t)(audio_renderer_base_t *base,
-                                           uint32_t element_id);
+typedef uint32_t (*func_get_element_channel_count_t)(
+    audio_renderer_base_t *base, uint32_t element_id);
+
+typedef uint32_t (*func_get_element_count_t)(audio_renderer_base_t *base);
 
 // AudioRendererAPI structure definition
 struct AudioRendererAPI {
@@ -82,9 +84,10 @@ struct AudioRendererAPI {
   func_render_t render;
   func_enable_head_tracking_t enable_head_tracking;
   func_set_head_rotation_t set_head_rotation;
-  func_get_channels_t get_channels;
+  func_get_channel_count_t get_channel_count;
   func_metadatas_elapse_t metadatas_elapse;
-  func_get_element_channels_t get_element_channels;
+  func_get_element_channel_count_t get_element_channel_count;
+  func_get_element_count_t get_element_count;
 };
 
 #ifdef __cplusplus

--- a/src/renderer/obr/obr.c
+++ b/src/renderer/obr/obr.c
@@ -164,6 +164,21 @@ static int _set_attribute(renderer_library_context_t *ctx,
       }
 
     } break;
+    case ck_attribute_remove_element: {
+      /* Only the last-added element can be removed (LIFO). OBR does not
+       * support removing an arbitrary element by index. If the requested
+       * index is not the last, return notsup; per-element DSP state is
+       * cleaned up when the renderer is closed. */
+
+      uint32_t index = *(const uint32_t *)value;
+      int num_elements = obr_get_number_of_audio_elements(obr->api);
+      if (num_elements == 0) return ck_oar_error_inval;
+      if (index != (uint32_t)(num_elements - 1)) return ck_oar_error_notsup;
+      if (obr_remove_last_audio_element(obr->api) < 0) {
+        warning("Failed to remove audio element at index %u", index);
+        return ck_oar_error_inval;
+      }
+    } break;
     case ck_attribute_element_head_locked: {
       element_head_locked_t *params = (element_head_locked_t *)value;
       int num_elements = obr_get_number_of_audio_elements(obr->api);

--- a/src/renderer/obr/obr_capi/obr_capi.cpp
+++ b/src/renderer/obr/obr_capi/obr_capi.cpp
@@ -135,6 +135,12 @@ int obr_get_number_of_audio_elements(obr_handle handle) {
   return (int)cast_(handle)->GetNumberOfAudioElements();
 }
 
+int obr_remove_last_audio_element(obr_handle handle) {
+  if (!handle) return -1;
+  auto status = cast_(handle)->RemoveLastAudioElement();
+  return status.ok() ? 0 : -1;
+}
+
 int obr_update_object_position(obr_handle handle, uint32_t index, float azimuth,
                                float elevation, float distance) {
   if (!handle) return -1;

--- a/src/renderer/obr/obr_capi/obr_capi.h
+++ b/src/renderer/obr/obr_capi/obr_capi.h
@@ -158,6 +158,15 @@ int obr_get_number_of_output_channels(obr_handle handle);
 int obr_get_number_of_audio_elements(obr_handle handle);
 
 /**
+ * @brief     Removes the last added audio element.
+ * @param     [in] handle : obr handle.
+ * @return    @0: success, @others: fail
+ * @note      Only the last-added element can be removed (LIFO).
+ *            Per-element DSP resources are released immediately.
+ */
+int obr_remove_last_audio_element(obr_handle handle);
+
+/**
  * @brief     Sets the position of an audio object.
  * @param     [in] handle : obr handle.
  * @param     [in] index : Index of the audio object.

--- a/src/renderer/renderer_library_api.h
+++ b/src/renderer/renderer_library_api.h
@@ -129,6 +129,8 @@ typedef enum ERenderingAttribute {
   ck_attribute_head_tracking,
   /** Add or modify rendering elements */
   ck_attribute_add_element,
+  /** Remove an audio element by index (value: uint32_t*) */
+  ck_attribute_remove_element,
   /** Set head-locked rendering mode for a specific audio element */
   ck_attribute_element_head_locked,
 } rendering_attribute_t;

--- a/tests/examples/BUILD.bazel
+++ b/tests/examples/BUILD.bazel
@@ -56,3 +56,14 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "test_remove_audio_element",
+    srcs = [
+        "test_remove_audio_element.c",
+        "test_framework.c",
+    ],
+    deps = [
+        "//:oar",
+    ],
+)
+

--- a/tests/examples/BUILD.bazel
+++ b/tests/examples/BUILD.bazel
@@ -61,6 +61,7 @@ cc_test(
     srcs = [
         "test_remove_audio_element.c",
         "test_framework.c",
+        "test_framework.h",
     ],
     deps = [
         "//:oar",

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -15,6 +15,10 @@ add_executable(test_object_based_rendering test_object_based_rendering.c)
 # Add the test for metadata unit processing (binaural OBR sub-frame)
 add_executable(test_metadata_unit_processing test_metadata_unit_processing.c)
 
+# Add the test for audio element removal
+add_executable(test_remove_audio_element test_remove_audio_element.c
+                                               test_framework.c)
+
 # Link the tests against the main oar library.
 # The 'oar' target is defined in the parent CMakeLists.txt,
 # so it's accessible here.
@@ -23,6 +27,7 @@ target_link_libraries(test_channel_based_rendering PRIVATE oar)
 target_link_libraries(test_scene_based_rendering PRIVATE oar)
 target_link_libraries(test_object_based_rendering PRIVATE oar)
 target_link_libraries(test_metadata_unit_processing PRIVATE oar)
+target_link_libraries(test_remove_audio_element PRIVATE oar)
 
 # Register tests with CTest so they run automatically in CI.
 add_test(NAME test_audio_element_types COMMAND test_audio_element_types)
@@ -30,7 +35,7 @@ add_test(NAME test_channel_based_rendering COMMAND test_channel_based_rendering)
 add_test(NAME test_scene_based_rendering COMMAND test_scene_based_rendering)
 add_test(NAME test_object_based_rendering COMMAND test_object_based_rendering)
 add_test(NAME test_metadata_unit_processing COMMAND test_metadata_unit_processing)
-
+add_test(NAME test_remove_audio_element COMMAND test_remove_audio_element)
 
 # Include directories are inherited from the parent project,
 # so oar.h and other headers should be found automatically.
@@ -41,12 +46,14 @@ set_property(TARGET test_channel_based_rendering PROPERTY C_STANDARD 99)
 set_property(TARGET test_scene_based_rendering PROPERTY C_STANDARD 99)
 set_property(TARGET test_object_based_rendering PROPERTY C_STANDARD 99)
 set_property(TARGET test_metadata_unit_processing PROPERTY C_STANDARD 99)
+set_property(TARGET test_remove_audio_element PROPERTY C_STANDARD 99)
 
 if(NOT MSVC)
   target_link_libraries(test_channel_based_rendering PRIVATE m)
   target_link_libraries(test_scene_based_rendering PRIVATE m)
   target_link_libraries(test_object_based_rendering PRIVATE m)
   target_link_libraries(test_metadata_unit_processing PRIVATE m)
+  target_link_libraries(test_remove_audio_element PRIVATE m)
 endif()
 
 # The HOA LFE test exercises the 120 Hz LFE low-pass, which is only compiled

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -1,0 +1,124 @@
+# OAR Test Framework
+
+## Overview
+
+The OAR test framework (`test_framework.h` / `test_framework.c`) provides a
+lightweight, header-based test harness for the `tests/examples/` suite. It
+standardises how test cases are declared, executed, and reported, and provides
+**crash isolation** so that a single test failure (including SIGABRT or
+segfault) does not prevent subsequent tests from running.
+
+## Key Features
+
+- **Assertion macros** — `TEST_ASSERT`, `TEST_ASSERT_EQ`, `TEST_ASSERT_NE`
+- **Test table registration** — declare a `test_entry_t[]` array and call
+  `run_all_tests()`
+- **Crash isolation** — each test runs in a child process (POSIX `fork()` /
+  Windows `_spawnl`)
+- **Cross-platform** — works on Linux, macOS, and Windows (MSVC)
+- **Summary report** — per-test PASSED/FAILED/CRASHED status table
+
+## Quick Start
+
+### 1. Write test functions
+
+Each test function has the signature `int (void)` and returns `TEST_PASS` (0)
+or `TEST_FAIL` (-1). Use the assertion macros for checks:
+
+```c
+#include "test_framework.h"
+
+static int test_my_feature(void) {
+    TEST_ASSERT(1 + 1 == 2, "math is broken");
+    TEST_ASSERT_EQ(some_function(), 0, "some_function should return 0");
+    return TEST_PASS;
+}
+```
+
+### 2. Declare a test table
+
+```c
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "my feature works", test_my_feature),
+    TEST_ENTRY("TC2", "another test", test_another),
+};
+```
+
+### 3. Write main()
+
+```c
+int main(int argc, char *argv[]) {
+    return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
+}
+```
+
+### 4. Build
+
+Add the test source file and `test_framework.c` to the build:
+
+**CMake** (`CMakeLists.txt`):
+```cmake
+add_executable(test_my_feature test_my_feature.c test_framework.c)
+target_link_libraries(test_my_feature PRIVATE oar)
+set_property(TARGET test_my_feature PROPERTY C_STANDARD 99)
+```
+
+**Bazel** (`BUILD.bazel`):
+```python
+cc_test(
+    name = "test_my_feature",
+    srcs = [
+        "test_my_feature.c",
+        "test_framework.c",
+    ],
+    deps = ["//:oar"],
+)
+```
+
+## API Reference
+
+### Macros
+
+| Macro | Description |
+|-------|-------------|
+| `TEST_ASSERT(cond, msg)` | Assert `cond` is true; on failure, print `msg` + line number and return `TEST_FAIL` |
+| `TEST_ASSERT_EQ(actual, expected, msg)` | Assert `actual == expected` |
+| `TEST_ASSERT_NE(actual, unexpected, msg)` | Assert `actual != unexpected` |
+| `TEST_START(name)` | Print a visual separator with the test name (optional) |
+| `TEST_ENTRY(name, desc, fn)` | Initialise a `test_entry_t` |
+| `NUM_TESTS(array)` | Number of elements in a static test array |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `test_fn_t` | `typedef int (*test_fn_t)(void)` — test function pointer |
+| `test_entry_t` | `{ const char *name; const char *description; test_fn_t fn; }` |
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `run_all_tests(tests, num_tests, argc, argv)` | Run all tests with crash isolation; returns 0 if all passed |
+
+## Crash Isolation
+
+Each test runs in a separate child process:
+
+- **POSIX**: `fork()` + `waitpid()` — the child runs the test and exits with
+  the result; the parent interprets the exit status (including signals).
+- **Windows**: `_spawnl(_P_WAIT, ...)` re-invokes the executable with
+  `--child <index>` to run a single test.
+
+This means a test that calls `abort()` or segfaults will be reported as
+`CRASHED` but will not affect other tests.
+
+## Adding a New Test File
+
+1. Create `test_my_feature.c` in `tests/examples/`
+2. `#include "test_framework.h"` and the OAR headers you need
+3. Write test functions returning `TEST_PASS` / `TEST_FAIL`
+4. Declare a `g_tests[]` array with `TEST_ENTRY` macros
+5. Write `main()` calling `run_all_tests()`
+6. Add the executable to `CMakeLists.txt` and `BUILD.bazel` (include
+   `test_framework.c` in the sources)

--- a/tests/examples/test_framework.c
+++ b/tests/examples/test_framework.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/**
+ * @file test_framework.c
+ * @brief Implementation of the common OAR test runner.
+ *
+ * Each test runs in a child process so that a crash (SIGABRT, segfault, etc.)
+ * does not prevent subsequent tests from running.
+ *
+ * On POSIX: fork() + waitpid().
+ * On Windows: _spawnl(_P_WAIT, ...) re-invokes the executable with
+ * "--child <index>" to run a single test in a child process.
+ */
+
+#include "test_framework.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#else
+#include <process.h>
+#include <windows.h>
+#endif
+
+/* --- Internal: run a single test in a child process -------------------- */
+
+static int run_test_in_child(test_entry_t *tests, int num_tests,
+                             int test_index) {
+  const char *name = tests[test_index].name;
+
+#ifndef _WIN32
+  test_fn_t test_fn = tests[test_index].fn;
+
+  fflush(stdout);
+  fflush(stderr);
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    perror("fork");
+    return TEST_FAIL;
+  }
+
+  if (pid == 0) {
+    /* Child: run the test and exit with its result. */
+    int ret = test_fn();
+    fflush(stdout);
+    fflush(stderr);
+    _exit(ret);
+  }
+
+  /* Parent: wait for the child and interpret the exit status. */
+  int status = 0;
+  waitpid(pid, &status, 0);
+
+  if (WIFEXITED(status)) {
+    int exit_code = WEXITSTATUS(status);
+    if (exit_code == 0) {
+      printf("[%s] PASSED\n", name);
+      return TEST_PASS;
+    } else {
+      printf("[%s] FAILED (exit %d)\n", name, exit_code);
+      return TEST_FAIL;
+    }
+  } else if (WIFSIGNALED(status)) {
+    int sig = WTERMSIG(status);
+    printf("[%s] CRASHED (signal %d: %s)\n", name, sig,
+           sig == SIGABRT ? "SIGABRT" : "other");
+    return TEST_FAIL;
+  }
+
+  printf("[%s] UNKNOWN failure\n", name);
+  return TEST_FAIL;
+#else
+  /* Windows: spawn a child process that runs a single test. */
+  char index_str[16];
+  char exe_path[1024];
+  DWORD len = GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
+  if (len == 0 || len >= sizeof(exe_path)) {
+    fprintf(stderr, "[%s] FAILED: cannot get executable path\n", name);
+    return TEST_FAIL;
+  }
+
+  snprintf(index_str, sizeof(index_str), "%d", test_index);
+
+  /* Quote the exe path for argv[0] to handle paths containing spaces. */
+  char quoted_path[1028];
+  snprintf(quoted_path, sizeof(quoted_path), "\"%s\"", exe_path);
+
+  errno = 0;
+  int exit_code =
+      _spawnl(_P_WAIT, exe_path, quoted_path, "--child", index_str, NULL);
+
+  if (exit_code == -1) {
+    /* -1 means _spawnl itself failed (the child never ran). */
+    fprintf(stderr, "[%s] FAILED: spawn error (errno %d: %s)\n", name, errno,
+            strerror(errno));
+    return TEST_FAIL;
+  } else if (exit_code == 0) {
+    printf("[%s] PASSED\n", name);
+    return TEST_PASS;
+  } else {
+    printf("[%s] FAILED/CRASHED (exit %d)\n", name, exit_code);
+    return TEST_FAIL;
+  }
+#endif
+}
+
+/* --- Public API --------------------------------------------------------- */
+
+int run_all_tests(test_entry_t *tests, int num_tests, int argc, char *argv[]) {
+  /* Child-process mode (Windows): run a single test by index. */
+  if (argc >= 3 && strcmp(argv[1], "--child") == 0) {
+    int index = atoi(argv[2]);
+    if (index < 0 || index >= num_tests) {
+      return 2; /* sentinel: invalid index */
+    }
+    int ret = tests[index].fn();
+    fflush(stdout);
+    fflush(stderr);
+    /* Map -1 (test failure) to exit code 1 so that -1 from _spawnl uniquely
+     * identifies a spawn failure rather than colliding with the child's own
+     * failure return. */
+    return (ret != 0) ? 1 : 0;
+  }
+
+  printf("========================================\n");
+  printf("Running %d test(s)\n", num_tests);
+  printf("========================================\n");
+
+  int result = 0;
+  int *tc_results = (int *)calloc(num_tests, sizeof(int));
+  if (!tc_results) {
+    fprintf(stderr, "Failed to allocate results array\n");
+    return 1;
+  }
+
+  for (int i = 0; i < num_tests; i++) {
+    printf("\n--- Running %s: %s ---\n", tests[i].name, tests[i].description);
+    tc_results[i] = run_test_in_child(tests, num_tests, i);
+    if (tc_results[i] != 0) result = 1;
+  }
+
+  printf("\n========================================\n");
+  printf("Test Summary:\n");
+  for (int i = 0; i < num_tests; i++) {
+    printf("  %s (%s): %s\n", tests[i].name, tests[i].description,
+           tc_results[i] == 0 ? "PASSED" : "FAILED/CRASHED");
+  }
+  printf("========================================\n");
+
+  free(tc_results);
+
+  if (result == 0) {
+    printf("\nAll tests passed.\n");
+  } else {
+    printf("\nSome tests failed or crashed. Review output above.\n");
+  }
+
+  return result;
+}

--- a/tests/examples/test_framework.h
+++ b/tests/examples/test_framework.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/**
+ * @file test_framework.h
+ * @brief Common test framework for OAR test suites.
+ *
+ * Provides assertion macros, a test-entry registration pattern, and a crash-
+ * isolated test runner. Each test file defines its own test_entry_t array and
+ * calls run_all_tests() from main().
+ *
+ * Usage example:
+ *
+ *   #include "test_framework.h"
+ *
+ *   static int test_something(void) {
+ *       TEST_ASSERT(1 + 1 == 2, "math is broken");
+ *       return TEST_PASS;
+ *   }
+ *
+ *   static test_entry_t g_tests[] = {
+ *       TEST_ENTRY("TC1", "something works", test_something),
+ *   };
+ *
+ *   int main(int argc, char *argv[]) {
+ *       return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
+ *   }
+ */
+
+#ifndef OAR_TEST_FRAMEWORK_H
+#define OAR_TEST_FRAMEWORK_H
+
+#include <stdio.h>
+
+/* --- Result codes ------------------------------------------------------- */
+
+#define TEST_PASS 0
+#define TEST_FAIL (-1)
+
+/* --- Test function type and entry --------------------------------------- */
+
+/** Test function signature: returns TEST_PASS (0) or TEST_FAIL (-1). */
+typedef int (*test_fn_t)(void);
+
+/** A single test case in a test table. */
+typedef struct {
+  const char *name;        /**< Short identifier, e.g. "TC1" */
+  const char *description; /**< Human-readable summary */
+  test_fn_t fn;            /**< Test function */
+} test_entry_t;
+
+/** Number of elements in a statically-declared test array. */
+#define NUM_TESTS(array) ((int)(sizeof(array) / sizeof((array)[0])))
+
+/** Convenience macro for initialising a test_entry_t. */
+#define TEST_ENTRY(n, d, f) \
+  { (n), (d), (f) }
+
+/* --- Assertion macros --------------------------------------------------- */
+
+/**
+ * Assert that @p cond is true. On failure, prints @p msg and line number to
+ * stderr, then returns TEST_FAIL from the enclosing function.
+ */
+#define TEST_ASSERT(cond, msg)                                  \
+  do {                                                          \
+    if (!(cond)) {                                              \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (msg), __LINE__); \
+      return TEST_FAIL;                                         \
+    }                                                           \
+  } while (0)
+
+/** Assert actual == expected. */
+#define TEST_ASSERT_EQ(actual, expected, msg) \
+  TEST_ASSERT((actual) == (expected), msg)
+
+/** Assert actual != unexpected. */
+#define TEST_ASSERT_NE(actual, unexpected, msg) \
+  TEST_ASSERT((actual) != (unexpected), msg)
+
+/* --- Visual helpers (optional) ----------------------------------------- */
+
+/** Print a visual separator before a test body. */
+#define TEST_START(name) printf("\n--- %s ---\n", (name))
+
+/* --- Runner ------------------------------------------------------------ */
+
+/**
+ * Run all tests in @p tests, each in a child process for crash isolation.
+ *
+ * On POSIX systems, fork() + waitpid() is used.
+ * On Windows, _spawnl(_P_WAIT, ...) re-invokes the executable with
+ * "--child <index>" to run a single test in a child process.
+ *
+ * When called with "--child <index>" (Windows child-process mode), runs only
+ * the test at @p index and returns its result directly.
+ *
+ * @param tests     Array of test entries.
+ * @param num_tests  Number of entries in @p tests.
+ * @param argc       Argument count from main().
+ * @param argv       Argument vector from main().
+ * @return 0 if all tests passed, non-zero if any failed.
+ */
+int run_all_tests(test_entry_t *tests, int num_tests, int argc, char *argv[]);
+
+#endif /* OAR_TEST_FRAMEWORK_H */

--- a/tests/examples/test_remove_audio_element.c
+++ b/tests/examples/test_remove_audio_element.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved.
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/*
+ * Test: oar_remove_audio_element()
+ *
+ * Scenarios:
+ *   1. Non-binaural: Add then remove a single element, verify count=0
+ *   2. Non-binaural: Add multiple elements, remove one, verify remaining
+ * renders
+ *   3. Non-binaural: Add, remove, re-add element
+ *   4. Binaural: Attempt non-LIFO removal (should fail, elements remain active)
+ *   5. Binaural: LIFO remove one, then remove all, verify renderer retained and
+ *      re-add works with rendering
+ */
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "oar.h"
+#include "oar_base.h"
+#include "test_framework.h"
+
+static oar_config_t create_stereo_config(void) {
+  oar_config_t config;
+  config.target_layout = ck_oar_layout_stereo;
+  config.samples_per_channel = 256;
+  config.sampling_rate = 48000;
+  return config;
+}
+
+static oar_config_t create_binaural_config(void) {
+  oar_config_t config;
+  config.target_layout = ck_oar_layout_binaural;
+  config.samples_per_channel = 256;
+  config.sampling_rate = 48000;
+  return config;
+}
+
+static void generate_sine(float *buffer, uint32_t samples, uint32_t channels,
+                          uint32_t ch_idx, float freq, float sr) {
+  for (uint32_t i = 0; i < samples; i++)
+    buffer[ch_idx * samples + i] =
+        (float)sin(2.0 * M_PI * freq * ((float)i / sr));
+}
+
+/* Feed sine wave to element, render, and verify output is non-silent.
+ * Returns 0 on success (non-silent), -1 on failure. */
+static int render_and_verify_non_silent(oar_t *oar, uint32_t element_id,
+                                        uint32_t element_channels,
+                                        const oar_config_t *cfg) {
+  uint32_t samples = oar_get_samples_per_channel(oar);
+  uint32_t output_ch = oar_get_number_of_output_channels(oar);
+
+  oar_audio_block_t input;
+  input.channels = element_channels;
+  input.samples_per_channel = samples;
+  input.data = (float *)calloc(element_channels * samples, sizeof(float));
+  if (!input.data) return -1;
+
+  generate_sine(input.data, samples, element_channels, 0, 440.0f,
+                (float)cfg->sampling_rate);
+
+  int ret = oar_update_audio_element_data(oar, element_id, &input);
+  free(input.data);
+  if (ret != 0) return -1;
+
+  oar_audio_block_t output;
+  output.channels = output_ch;
+  output.samples_per_channel = samples;
+  output.data = (float *)calloc(output_ch * samples, sizeof(float));
+  if (!output.data) return -1;
+
+  ret = oar_render(oar, &output);
+  if (ret != 0) {
+    free(output.data);
+    return -1;
+  }
+
+  int is_silent = 1;
+  for (uint32_t i = 0; i < output_ch * samples; i++) {
+    if (fabsf(output.data[i]) > 1e-9f) {
+      is_silent = 0;
+      break;
+    }
+  }
+  free(output.data);
+  return is_silent ? -1 : 0;
+}
+
+/* Scenario 1: Non-binaural — Add then remove a single element */
+static int test_remove_single_element(void) {
+  TEST_START("test_remove_single_element");
+
+  oar_config_t cfg = create_stereo_config();
+  oar_t *oar = oar_create(&cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_channel_based;
+  elem_cfg.cbc.layout = ck_oar_layout_mono;
+
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
+
+  uint32_t count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 1, "element count should be 1");
+
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret == 0, "oar_remove_audio_element failed");
+
+  count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 0, "element count should be 0 after removal");
+
+  uint32_t ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch == 0, "removed element should have 0 channels");
+
+  /* Verify removing non-existent element returns error */
+  ret = oar_remove_audio_element(oar, 99);
+  TEST_ASSERT(ret != 0, "should fail to remove non-existent element");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* Scenario 2: Non-binaural — Remove one of multiple, verify remaining renders
+ */
+static int test_remove_one_of_multiple_elements(void) {
+  TEST_START("test_remove_one_of_multiple_elements");
+
+  oar_config_t cfg = create_stereo_config();
+  oar_t *oar = oar_create(&cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_channel_based;
+  elem_cfg.cbc.layout = ck_oar_layout_mono;
+
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 1 failed");
+
+  ret = oar_add_audio_element(oar, gid, 2, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 2 failed");
+
+  uint32_t count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 2, "element count should be 2");
+
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret == 0, "remove element 1 failed");
+
+  count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 1, "element count should be 1 after removal");
+
+  uint32_t ch = oar_get_number_of_audio_element_channels(oar, 2);
+  TEST_ASSERT(ch > 0, "element 2 should still have channels");
+
+  ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch == 0, "element 1 should have 0 channels");
+
+  /* Verify remaining element renders non-silent output */
+  ch = oar_get_number_of_audio_element_channels(oar, 2);
+  TEST_ASSERT(render_and_verify_non_silent(oar, 2, ch, &cfg) == 0,
+              "output should not be silent");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* Scenario 3: Non-binaural — Add, remove, re-add element */
+static int test_readd_after_remove(void) {
+  TEST_START("test_readd_after_remove");
+
+  oar_config_t cfg = create_stereo_config();
+  oar_t *oar = oar_create(&cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_channel_based;
+  elem_cfg.cbc.layout = ck_oar_layout_mono;
+
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element failed");
+
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret == 0, "remove element failed");
+
+  ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "re-add element failed");
+
+  uint32_t count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 1, "element count should be 1 after re-add");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* Scenario 4: Binaural — Attempt non-LIFO removal (should fail gracefully) */
+static int test_binaural_remove_non_lifo(void) {
+  TEST_START("test_binaural_remove_non_lifo");
+
+  oar_config_t cfg = create_binaural_config();
+  oar_t *oar = oar_create(&cfg);
+  if (!oar) {
+    printf("SKIP: binaural not supported\n");
+    return TEST_PASS;
+  }
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_channel_based;
+  elem_cfg.cbc.layout = ck_oar_layout_mono;
+
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 1 failed");
+
+  ret = oar_add_audio_element(oar, gid, 2, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 2 failed");
+
+  /* Attempt to remove element 1 (non-LIFO) — OBR only supports LIFO.
+   * The removal should fail and return an error, but both elements
+   * should remain active and rendering should be unaffected. */
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret != 0, "non-LIFO removal should fail");
+
+  /* Both elements should still be accessible */
+  uint32_t ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch > 0, "element 1 should still have channels");
+  ch = oar_get_number_of_audio_element_channels(oar, 2);
+  TEST_ASSERT(ch > 0, "element 2 should still have channels");
+
+  /* Feed data to both elements and render — should produce non-silent output */
+  ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(render_and_verify_non_silent(oar, 1, ch, &cfg) == 0,
+              "output should not be silent after failed removal");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* Scenario 5: Binaural — LIFO remove one, then remove all, verify renderer
+ * retained and re-add works with rendering.
+ *
+ * This test verifies the design principle that the binaural renderer's
+ * lifecycle is tied to the audio group: it is created in oar_add_audio_group
+ * and destroyed in oar_destroy, not when elements are removed. */
+static int test_binaural_remove_all_and_readd(void) {
+  TEST_START("test_binaural_remove_all_and_readd");
+
+  oar_config_t cfg = create_binaural_config();
+  oar_t *oar = oar_create(&cfg);
+  if (!oar) {
+    printf("SKIP: binaural not supported\n");
+    return TEST_PASS;
+  }
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  oar_audio_element_config_t elem_cfg;
+  memset(&elem_cfg, 0, sizeof(elem_cfg));
+  elem_cfg.type = ck_channel_based;
+  elem_cfg.cbc.layout = ck_oar_layout_mono;
+
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 1 failed");
+
+  ret = oar_add_audio_element(oar, gid, 2, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element 2 failed");
+
+  /* Step 1: Remove element 2 (LIFO), verify element 1 still renders */
+  ret = oar_remove_audio_element(oar, 2);
+  TEST_ASSERT(ret == 0, "remove element 2 (LIFO) failed");
+
+  uint32_t ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch > 0,
+              "element 1 should still have channels after LIFO removal");
+
+  TEST_ASSERT(render_and_verify_non_silent(oar, 1, ch, &cfg) == 0,
+              "element 1 should render after LIFO removal of element 2");
+
+  /* Step 2: Remove element 1 (now the last), verify renderer is retained.
+   * The binaural renderer is NOT destroyed when all elements are removed —
+   * its lifecycle is tied to the audio group. oar_get_number_of_audio_elements
+   * returns the renderer count (1 = the empty binaural renderer). */
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret == 0, "remove element 1 failed");
+
+  uint32_t count = oar_get_number_of_audio_elements(oar);
+  TEST_ASSERT(count == 1,
+              "binaural renderer should be retained after removing all "
+              "elements (count=1)");
+
+  ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch == 0, "removed element should have 0 channels");
+
+  /* Step 3: Re-add a new element — should find the existing renderer and
+   * trigger re-open via add_element. Verify it has channels and renders. */
+  ret = oar_add_audio_element(oar, gid, 3, &elem_cfg);
+  TEST_ASSERT(ret == 0, "re-add element 3 after removing all failed");
+
+  ch = oar_get_number_of_audio_element_channels(oar, 3);
+  TEST_ASSERT(ch > 0, "re-added element 3 should have channels");
+
+  TEST_ASSERT(render_and_verify_non_silent(oar, 3, ch, &cfg) == 0,
+              "re-added element should render non-silent output");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* --- Test table --------------------------------------------------------- */
+
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "remove single element", test_remove_single_element),
+    TEST_ENTRY("TC2", "remove one of multiple",
+               test_remove_one_of_multiple_elements),
+    TEST_ENTRY("TC3", "re-add after remove", test_readd_after_remove),
+    TEST_ENTRY("TC4", "binaural non-LIFO removal",
+               test_binaural_remove_non_lifo),
+    TEST_ENTRY("TC5", "binaural remove all and re-add",
+               test_binaural_remove_all_and_readd),
+};
+
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
+}

--- a/tests/examples/test_remove_audio_element.c
+++ b/tests/examples/test_remove_audio_element.c
@@ -311,14 +311,13 @@ static int test_binaural_remove_all_and_readd(void) {
   /* Step 2: Remove element 1 (now the last), verify renderer is retained.
    * The binaural renderer is NOT destroyed when all elements are removed —
    * its lifecycle is tied to the audio group. oar_get_number_of_audio_elements
-   * returns the renderer count (1 = the empty binaural renderer). */
+   * returns the actual element count (0 = no elements, but renderer exists). */
   ret = oar_remove_audio_element(oar, 1);
   TEST_ASSERT(ret == 0, "remove element 1 failed");
 
   uint32_t count = oar_get_number_of_audio_elements(oar);
-  TEST_ASSERT(count == 1,
-              "binaural renderer should be retained after removing all "
-              "elements (count=1)");
+  TEST_ASSERT(count == 0,
+              "element count should be 0 after removing all elements");
 
   ch = oar_get_number_of_audio_element_channels(oar, 1);
   TEST_ASSERT(ch == 0, "removed element should have 0 channels");


### PR DESCRIPTION
- Implement oar_remove_audio_element with separate paths for binaural (multi-element) and single-element renderers; binaural renderer is retained after element removal, tied to audio group lifecycle
- Add OBR LIFO-only element removal via obr_remove_last_audio_element and ck_attribute_remove_element attribute
- Add remove_element callback to AudioRendererAPI and implement audio_elements_renderer_remove_element with index/offset rebasing
- Add crash-isolated test framework (test_framework.c/h) with fork-based process isolation
- Add 5 test scenarios covering single/multiple removal, re-add, and binaural non-LIFO failure cases