### PR TITLE
Fix uninitialized memory rendering in binaural staging buffer

### DIFF
--- a/src/renderer/audio_element_renderer.c
+++ b/src/renderer/audio_element_renderer.c
@@ -210,7 +210,7 @@ audio_element_renderer_t *audio_element_renderer_new(
   info("Using self library %s for stream %u", self->base.lib->id, id);
   self->base.block.channels = audio_element_renderer_get_channels(&self->base);
   self->base.block.samples_per_channel = oar_config->samples_per_channel;
-  self->base.block.data = def_malloc(
+  self->base.block.data = def_mallocz(
       float, self->base.block.channels * self->base.block.samples_per_channel);
   if (!self->base.block.data) {
     audio_element_renderer_delete(&self->base);
@@ -363,6 +363,12 @@ int audio_element_renderer_render(audio_renderer_base_t *base,
     wav_writer_write(self->rendered, out_block->data,
                      out_block->samples_per_channel, out_block->channels);
 #endif
+
+  if (self->base.block.data) {
+    memset(self->base.block.data, 0,
+           self->base.block.channels * self->base.block.samples_per_channel *
+               sizeof(float));
+  }
 
   return ret;
 }

--- a/src/renderer/audio_elements_renderer.c
+++ b/src/renderer/audio_elements_renderer.c
@@ -304,7 +304,7 @@ int audio_elements_renderer_add_data(audio_renderer_base_t *base,
     if (!self->base.block.data) {
       debug("channels %d, samples %d", self->channels_count,
             block->samples_per_channel);
-      self->base.block.data = def_malloc(
+      self->base.block.data = def_mallocz(
           float, (self->channels_count * block->samples_per_channel));
       if (!self->base.block.data) {
         return ck_oar_error_nomem;
@@ -319,6 +319,11 @@ int audio_elements_renderer_add_data(audio_renderer_base_t *base,
 
       if (!data) return ck_oar_error_nomem;
       self->base.block.data = data;
+      memset((self->base.block.data +
+              self->base.block.channels * self->base.block.samples_per_channel),
+             0,
+             ((self->channels_count - self->base.block.channels) *
+              self->base.block.samples_per_channel * sizeof(float)));
     }
     self->base.block.channels = self->channels_count;
     self->elements_updated = 0;
@@ -393,6 +398,12 @@ int audio_elements_renderer_render(audio_renderer_base_t *base,
     wav_writer_write(self->rendered, output_block->data,
                      output_block->samples_per_channel, output_block->channels);
 #endif
+
+  if (self->base.block.data) {
+    memset(self->base.block.data, 0,
+           self->base.block.channels * self->base.block.samples_per_channel *
+               sizeof(float));
+  }
 
   return ret;
 }


### PR DESCRIPTION
Fixes #33

## Problem

When an audio element is added mid-stream, the staging buffer allocated with `def_malloc`/`def_realloc` is never zeroed. Unwritten channel regions contain uninitialized heap data, which gets convolved into the binaural output as broadband noise. The bug is nondeterministic — invisible on fresh heaps (zero-filled OS pages) but audible in long-running hosts where the allocator recycles freed blocks.

## Fix

Following the issue reporter's suggestion, the fix ensures all staging buffer memory is zeroed at three points: initial allocation uses `def_mallocz` (calloc), newly grown channels after `def_realloc` are `memset` to zero (preserving same-frame data from other elements), and the entire buffer is cleared at the end of each `render()` call to prevent stale data across frames. Applied consistently to both `audio_elements_renderer.c` (binaural) and `audio_element_renderer.c` (single-element).

## Verification

Verified with the issue reporter's `repro_addelem.c` + `dirtymalloc.c` tooling (Linux-adapted, `LD_PRELOAD` + `malloc_usable_size`):

| Version | Interposer | rms(A-B) | peak\|A-B\| | Result |
|---------|-----------|----------|-------------|--------|
| Before  | No | 0 | 0 | Hidden (zero-filled OS pages) |
| Before  | Yes | 0.401017 | 0.624996 | ❌ Bug confirmed (279% of signal RMS) |
| **After** | **No** | **0** | **0** | **✅ Fixed** |
| **After** | **Yes** | **0** | **0** | **✅ Fixed (even with poisoned memory)** |
