### PR TITLE
Fix gain interpolation to use dB domain instead of linear domain

### DIFF
--- a/src/oar.c
+++ b/src/oar.c
@@ -453,7 +453,6 @@ int oar_update_metadata(oar_t *oar, uint32_t gid,
   if (metadata->type == ck_metadata_gain) {
     clone = metadata_clone(metadata);
     if (!clone) return ck_oar_error_nomem;
-    metadata_gain_linear(clone);
 
     if (group->output_gain.metadatas) {
       if (queue_push(group->output_gain.metadatas,

--- a/src/oar_utils.c
+++ b/src/oar_utils.c
@@ -443,49 +443,6 @@ void metadata_delete(oar_metadata_t *metadata) {
   def_free(metadata);
 }
 
-int metadata_gain_linear(oar_metadata_t *metadata) {
-  if (!metadata || metadata->type != ck_metadata_gain) {
-    return ck_oar_error_inval;
-  }
-
-  switch (metadata->gain.param_type) {
-    case ck_param_constant:
-      // Convert constant gain from dB to linear
-      metadata->gain.constant_gain =
-          db_to_linear_float32(metadata->gain.constant_gain);
-      break;
-
-    case ck_param_multiple:
-      // Convert each gain value in the array from dB to linear
-      if (metadata->gain.gain_array && metadata->duration > 0) {
-        for (int i = 0; i < metadata->duration; i++) {
-          metadata->gain.gain_array[i] =
-              db_to_linear_float32(metadata->gain.gain_array[i]);
-        }
-      }
-      break;
-
-    case ck_param_animated:
-      // Convert animated gain values from dB to linear
-      metadata->gain.animated_gains.data.start =
-          db_to_linear_float32(metadata->gain.animated_gains.data.start);
-      metadata->gain.animated_gains.data.end =
-          db_to_linear_float32(metadata->gain.animated_gains.data.end);
-      // For bezier animation, also convert the control point
-      if (metadata->gain.animated_gains.animation_type ==
-          ck_animation_type_bezier) {
-        metadata->gain.animated_gains.data.control =
-            db_to_linear_float32(metadata->gain.animated_gains.data.control);
-      }
-      break;
-
-    default:
-      return ck_oar_error_inval;
-  }
-
-  return ck_oar_ok;
-}
-
 float db_to_linear_float32(float db) { return powf(10.0f, 0.05f * db); }
 
 #ifdef __as_dbg__

--- a/src/oar_utils.h
+++ b/src/oar_utils.h
@@ -46,7 +46,6 @@ polar_t cartesian_to_polar_sector_float32(cartesian_t cartesian);
 // Metadata utility functions
 oar_metadata_t *metadata_clone(const oar_metadata_t *metadata);
 void metadata_delete(oar_metadata_t *metadata);
-int metadata_gain_linear(oar_metadata_t *metadata);
 
 float db_to_linear_float32(float db);
 

--- a/src/renderer/audio_renderer_base.c
+++ b/src/renderer/audio_renderer_base.c
@@ -132,7 +132,6 @@ int audio_element_context_update_gain(audio_element_context_t *ctx,
 
   clone = metadata_clone(metadata);
   if (!clone) return ck_oar_error_nomem;
-  metadata_gain_linear(clone);
   queue_push(gain->metadatas, def_value_wrap_instance_ptr(clone));
   gain->duration += metadata->duration;
 
@@ -203,6 +202,11 @@ int audio_block_sub_frames_apply_gain(oar_audio_block_t *block,
 
   if (!gain_item || !gain_item->metadatas) return ck_oar_error_inval;
 
+  /* Cache: avoid repeated db_to_linear_float32() for constant/step gain
+   * across multiple sub-frames within the same metadata */
+  oar_metadata_t *cached_metadata = NULL;
+  float cached_linear_gain = 1.0f;
+
   while (processed_samples < total_samples) {
     float cumulative_gain = 1.0f;
     uint32_t current_unit_samples = sub_frame_samples;
@@ -225,35 +229,61 @@ int audio_block_sub_frames_apply_gain(oar_audio_block_t *block,
         float gain_value = 1.0f;
 
         if (metadata->gain.param_type == ck_param_constant) {
-          gain_value = metadata->gain.constant_gain;
+          /* constant gain is unchanged across sub-frames, cache it */
+          if (metadata != cached_metadata) {
+            cached_linear_gain =
+                db_to_linear_float32(metadata->gain.constant_gain);
+            cached_metadata = metadata;
+          }
+          gain_value = cached_linear_gain;
         } else if (metadata->gain.param_type == ck_param_multiple) {
+          cached_metadata =
+              NULL; /* multiple gain varies per sample, no cache */
           uint32_t relative_pos = sample_gain_position - accumulated_duration;
           if (relative_pos < metadata->duration && metadata->gain.gain_array) {
-            gain_value = metadata->gain.gain_array[relative_pos];
+            gain_value =
+                db_to_linear_float32(metadata->gain.gain_array[relative_pos]);
           } else {
             warning("Gain array out of bounds for metadata id %u",
                     metadata->gain.id);
           }
         } else if (metadata->gain.param_type == ck_param_animated) {
+          /* Default to 0 dB (unity) if no animation type matches */
+          gain_value = 0.0f;
           uint32_t relative_pos = sample_gain_position - accumulated_duration;
           if (metadata->gain.animated_gains.animation_type ==
-              ck_animation_type_step)
-            gain_value = metadata->gain.animated_gains.data.start;
-          else if (metadata->gain.animated_gains.animation_type ==
-                   ck_animation_type_linear) {
-            gain_value = animated_bezier_linear_calculate(
-                &metadata->gain.animated_gains.data,
-                bezier_linear_factor_get(metadata->duration, relative_pos));
-          } else if (metadata->gain.animated_gains.animation_type ==
-                     ck_animation_type_bezier) {
-            gain_value = animated_bezier_quadratic_calculate(
-                &metadata->gain.animated_gains.data,
-                bezier_quadratic_factor_get(
-                    0,
-                    metadata->gain.animated_gains.data.control_relative_time *
-                            metadata->duration +
-                        0.5f,
-                    metadata->duration, relative_pos));
+              ck_animation_type_step) {
+            /* step gain is unchanged across sub-frames, cache it */
+            if (metadata != cached_metadata) {
+              cached_linear_gain = db_to_linear_float32(
+                  metadata->gain.animated_gains.data.start);
+              cached_metadata = metadata;
+            }
+            gain_value = cached_linear_gain;
+          } else {
+            cached_metadata = NULL; /* linear/bezier varies, no cache */
+            if (metadata->gain.animated_gains.animation_type ==
+                ck_animation_type_linear) {
+              gain_value = animated_bezier_linear_calculate(
+                  &metadata->gain.animated_gains.data,
+                  bezier_linear_factor_get(metadata->duration, relative_pos));
+            } else if (metadata->gain.animated_gains.animation_type ==
+                       ck_animation_type_bezier) {
+              gain_value = animated_bezier_quadratic_calculate(
+                  &metadata->gain.animated_gains.data,
+                  bezier_quadratic_factor_get(
+                      0,
+                      metadata->gain.animated_gains.data.control_relative_time *
+                              metadata->duration +
+                          0.5f,
+                      metadata->duration, relative_pos));
+            } else {
+              warning("Unknown animation type %d for gain metadata id %u",
+                      metadata->gain.animated_gains.animation_type,
+                      metadata->gain.id);
+            }
+            /* Interpolate in dB domain, then convert to linear */
+            gain_value = db_to_linear_float32(gain_value);
           }
         }
 


### PR DESCRIPTION
Background: IAMF/OAR specs transmit gain parameters in dB, but neither spec explicitly specifies whether interpolation should occur in dB or linear domain. Since human loudness perception is logarithmic, dB-domain interpolation produces more perceptually natural results. Previously, metadata_gain_linear() converted dB to linear before interpolation, causing volume to stay loud then drop abruptly — perceptually unnatural.

- Remove metadata_gain_linear() and its calls in oar.c and audio_renderer_base.c; gain values now remain in dB until application
- Rewrite audio_block_sub_frames_apply_gain() to interpolate in dB domain then convert to linear via db_to_linear_float32() per sub-frame
- Add constant/step gain cache to avoid repeated powf() calls across sub-frames, mitigating the per-sample conversion overhead introduced by moving dB-to-linear conversion from metadata-queue time to render time