### PR TITLE
Fix head rotation state loss on binaural group re-open

### DIFF
--- a/src/oar.c
+++ b/src/oar.c
@@ -320,6 +320,14 @@ int oar_add_audio_element(oar_t *oar, uint32_t gid, uint32_t id,
             ? 1
             : 0;
     renderer->impl->set_element_head_locked(renderer, id, lock);
+
+    /* Re-apply head rotation: when the binaural group was drained to zero
+     * elements and is re-opened, the OBR handle is recreated and the
+     * previously set rotation is lost. oar->head_rotation always holds the
+     * latest value, so re-apply it here. */
+    if (oar->enable_head_tracking)
+      renderer->impl->set_head_rotation(renderer, &oar->head_rotation);
+
     return ck_oar_ok;
   }
 


### PR DESCRIPTION
- Re-apply oar->head_rotation after add_element when head tracking is enabled, fixing rotation state lost when OBR handle is recreated after binaural group is drained to zero elements

New TCs: https://github.com/AOMediaCodec/oar/pull/38/changes/eb0e34f9a8ca65cb337044a442bedc97d90b21eb