### PR TITLE
Refactor test suite to use shared helpers and test framework

### DIFF
--- a/tests/examples/BUILD.bazel
+++ b/tests/examples/BUILD.bazel
@@ -1,10 +1,26 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_test", "cc_library")
+
+# Shared test infrastructure: test_framework + test_helpers
+cc_library(
+    name = "oar_test_common",
+    srcs = [
+        "test_framework.c",
+        "test_helpers.c",
+    ],
+    hdrs = [
+        "test_framework.h",
+        "test_helpers.h",
+    ],
+    deps = [
+        "//:oar",
+    ],
+)
 
 cc_test(
     name = "test_audio_element_types",
     srcs = ["test_audio_element_types.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
@@ -12,7 +28,7 @@ cc_test(
     name = "test_channel_based_rendering",
     srcs = ["test_channel_based_rendering.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
@@ -28,7 +44,7 @@ cc_test(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
@@ -36,7 +52,7 @@ cc_test(
     name = "test_object_based_rendering",
     srcs = ["test_object_based_rendering.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
@@ -44,7 +60,7 @@ cc_test(
     name = "test_scene_based_rendering",
     srcs = ["test_scene_based_rendering.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
@@ -52,19 +68,15 @@ cc_test(
     name = "test_metadata_unit_processing",
     srcs = ["test_metadata_unit_processing.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 
 cc_test(
     name = "test_remove_audio_element",
-    srcs = [
-        "test_remove_audio_element.c",
-        "test_framework.c",
-        "test_framework.h",
-    ],
+    srcs = ["test_remove_audio_element.c"],
     deps = [
-        "//:oar",
+        ":oar_test_common",
     ],
 )
 

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,68 +1,35 @@
 # CMakeLists.txt for tests/examples
 
-# Add the test for audio_element_type_t
-add_executable(test_audio_element_types test_audio_element_types.c)
-
-# Add the test for channel-based rendering
-add_executable(test_channel_based_rendering test_channel_based_rendering.c)
-
-# Add the test for scene-based rendering
-add_executable(test_scene_based_rendering test_scene_based_rendering.c)
-
-# Add the test for object-based rendering
-add_executable(test_object_based_rendering test_object_based_rendering.c)
-
-# Add the test for metadata unit processing (binaural OBR sub-frame)
-add_executable(test_metadata_unit_processing test_metadata_unit_processing.c)
-
-# Add the test for audio element removal
-add_executable(test_remove_audio_element test_remove_audio_element.c
-                                               test_framework.c)
-
-# Link the tests against the main oar library.
-# The 'oar' target is defined in the parent CMakeLists.txt,
-# so it's accessible here.
-target_link_libraries(test_audio_element_types PRIVATE oar)
-target_link_libraries(test_channel_based_rendering PRIVATE oar)
-target_link_libraries(test_scene_based_rendering PRIVATE oar)
-target_link_libraries(test_object_based_rendering PRIVATE oar)
-target_link_libraries(test_metadata_unit_processing PRIVATE oar)
-target_link_libraries(test_remove_audio_element PRIVATE oar)
-
-# Register tests with CTest so they run automatically in CI.
-add_test(NAME test_audio_element_types COMMAND test_audio_element_types)
-add_test(NAME test_channel_based_rendering COMMAND test_channel_based_rendering)
-add_test(NAME test_scene_based_rendering COMMAND test_scene_based_rendering)
-add_test(NAME test_object_based_rendering COMMAND test_object_based_rendering)
-add_test(NAME test_metadata_unit_processing COMMAND test_metadata_unit_processing)
-add_test(NAME test_remove_audio_element COMMAND test_remove_audio_element)
-
-# Include directories are inherited from the parent project,
-# so oar.h and other headers should be found automatically.
-
-# Enable C99 standard for the tests. Also link math library for sine wave.
-set_property(TARGET test_audio_element_types PROPERTY C_STANDARD 99)
-set_property(TARGET test_channel_based_rendering PROPERTY C_STANDARD 99)
-set_property(TARGET test_scene_based_rendering PROPERTY C_STANDARD 99)
-set_property(TARGET test_object_based_rendering PROPERTY C_STANDARD 99)
-set_property(TARGET test_metadata_unit_processing PROPERTY C_STANDARD 99)
-set_property(TARGET test_remove_audio_element PROPERTY C_STANDARD 99)
-
+# --- Shared test infrastructure -------------------------------------------
+# Build test_framework.c and test_helpers.c into a static library so that
+# each test target only needs its own .c file + link oar_test_common.
+add_library(oar_test_common STATIC test_framework.c test_helpers.c)
+target_link_libraries(oar_test_common PUBLIC oar)
+set_property(TARGET oar_test_common PROPERTY C_STANDARD 99)
 if(NOT MSVC)
-  target_link_libraries(test_channel_based_rendering PRIVATE m)
-  target_link_libraries(test_scene_based_rendering PRIVATE m)
-  target_link_libraries(test_object_based_rendering PRIVATE m)
-  target_link_libraries(test_metadata_unit_processing PRIVATE m)
-  target_link_libraries(test_remove_audio_element PRIVATE m)
+  target_link_libraries(oar_test_common PUBLIC m)
 endif()
+
+# --- Helper function -------------------------------------------------------
+# Creates a test executable, links it, and registers it with CTest.
+function(oar_add_test name)
+  add_executable(${name} ${name}.c)
+  target_link_libraries(${name} PRIVATE oar_test_common)
+  set_property(TARGET ${name} PROPERTY C_STANDARD 99)
+  add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+# --- Test targets ---------------------------------------------------------
+
+oar_add_test(test_audio_element_types)
+oar_add_test(test_channel_based_rendering)
+oar_add_test(test_scene_based_rendering)
+oar_add_test(test_object_based_rendering)
+oar_add_test(test_metadata_unit_processing)
+oar_add_test(test_remove_audio_element)
 
 # The HOA LFE test exercises the 120 Hz LFE low-pass, which is only compiled
 # into the library when OAR_ENABLE_HOA_LFE is ON.
 if(OAR_ENABLE_HOA_LFE)
-    add_executable(test_hoa_lfe_rendering test_hoa_lfe_rendering.c)
-    target_link_libraries(test_hoa_lfe_rendering PRIVATE oar)
-    if(NOT MSVC)
-        target_link_libraries(test_hoa_lfe_rendering PRIVATE m)
-    endif()
-    set_property(TARGET test_hoa_lfe_rendering PROPERTY C_STANDARD 99)
+  oar_add_test(test_hoa_lfe_rendering)
 endif()

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -8,6 +8,10 @@ standardises how test cases are declared, executed, and reported, and provides
 **crash isolation** so that a single test failure (including SIGABRT or
 segfault) does not prevent subsequent tests from running.
 
+A companion module (`test_helpers.h` / `test_helpers.c`) provides shared
+utility functions — signal generation, config/element creation, metadata
+helpers, and output verification — that are common across multiple test files.
+
 ## Key Features
 
 - **Assertion macros** — `TEST_ASSERT`, `TEST_ASSERT_EQ`, `TEST_ASSERT_NE`
@@ -17,6 +21,8 @@ segfault) does not prevent subsequent tests from running.
   Windows `_spawnl`)
 - **Cross-platform** — works on Linux, macOS, and Windows (MSVC)
 - **Summary report** — per-test PASSED/FAILED/CRASHED status table
+- **Shared helpers** — `test_helpers.c` provides signal generation, config
+  creation, metadata helpers, and output verification utilities
 
 ## Quick Start
 
@@ -54,24 +60,26 @@ int main(int argc, char *argv[]) {
 
 ### 4. Build
 
-Add the test source file and `test_framework.c` to the build:
+`test_framework.c` and `test_helpers.c` are compiled into a shared static
+library (`oar_test_common`). Each test target only needs its own `.c` file
+linked against `oar_test_common`.
 
 **CMake** (`CMakeLists.txt`):
 ```cmake
-add_executable(test_my_feature test_my_feature.c test_framework.c)
-target_link_libraries(test_my_feature PRIVATE oar)
-set_property(TARGET test_my_feature PROPERTY C_STANDARD 99)
+# The shared library is already defined at the top of CMakeLists.txt:
+# add_library(oar_test_common STATIC test_framework.c test_helpers.c)
+# target_link_libraries(oar_test_common PUBLIC oar)
+
+# To add a new test, use the helper function:
+oar_add_test(test_my_feature)
 ```
 
 **Bazel** (`BUILD.bazel`):
 ```python
 cc_test(
     name = "test_my_feature",
-    srcs = [
-        "test_my_feature.c",
-        "test_framework.c",
-    ],
-    deps = ["//:oar"],
+    srcs = ["test_my_feature.c"],
+    deps = [":oar_test_common"],
 )
 ```
 
@@ -117,8 +125,9 @@ This means a test that calls `abort()` or segfaults will be reported as
 
 1. Create `test_my_feature.c` in `tests/examples/`
 2. `#include "test_framework.h"` and the OAR headers you need
+   - Include `test_helpers.h` if you need shared utility functions
 3. Write test functions returning `TEST_PASS` / `TEST_FAIL`
 4. Declare a `g_tests[]` array with `TEST_ENTRY` macros
 5. Write `main()` calling `run_all_tests()`
-6. Add the executable to `CMakeLists.txt` and `BUILD.bazel` (include
-   `test_framework.c` in the sources)
+6. Add the test to `CMakeLists.txt` (via `oar_add_test()`) and `BUILD.bazel`
+   (via `cc_test` with `deps = [":oar_test_common"]`)

--- a/tests/examples/test_audio_element_types.c
+++ b/tests/examples/test_audio_element_types.c
@@ -10,267 +10,142 @@
  * www.aomedia.org/license/patent.
  */
 
+/**
+ * @file test_audio_element_types.c
+ * @brief Test cases for audio element type configuration and channel counts.
+ *
+ * Test matrix:
+ *   TC1: ck_channel_based element (stereo layout → 2 channels)
+ *   TC2: ck_scene_based element (1OA → 4 channels)
+ *   TC3: ck_object_based element (1 object → 1 channel)
+ *   TC4: Multiple elements of different types in separate groups
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-// Include the OAR header
 #include "oar.h"
 #include "oar_base.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
-// Helper function to create a basic OAR config
-oar_config_t create_default_oar_config() {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_stereo;
-  config.samples_per_channel = 1024;
-  config.sampling_rate = 48000;
-  return config;
-}
+/* TC1: ck_channel_based audio element (stereo → 2 channels) */
+static int test_channel_based_element(void) {
+  TEST_START("TC1: channel-based element (stereo)");
 
-// Test case for ck_channel_based audio element type
-int test_channel_based_element() {
-  printf("Testing ck_channel_based audio element...\n");
-
-  oar_config_t config = create_default_oar_config();
+  oar_config_t config = create_config(ck_oar_layout_stereo, 1024, 48000);
   oar_t *oar = oar_create(&config);
-  if (oar == NULL) {
-    fprintf(stderr, "Error: Failed to create OAR object\n");
-    return -1;
-  }
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Error: Failed to add audio group, error code: %d\n",
-            group_id);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added successfully.\n", group_id);
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t element_config;
-  element_config.type = ck_channel_based;
-  element_config.cbc.layout = ck_oar_layout_stereo;
-  memset(&element_config.parameters, 0, sizeof(parameter_set_t));
-
-  int ret = oar_add_audio_element(oar, group_id, 1, &element_config);
-  printf("oar_add_audio_element returned: %d\n", ret);
-  if (ret != 0) {
-    fprintf(stderr,
-            "Error: Failed to add audio element, expected 0 but got %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_stereo);
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
   uint32_t num_channels = oar_get_number_of_audio_element_channels(oar, 1);
-  if (num_channels != 2) {  // Stereo layout has 2 channels
-    fprintf(stderr, "Error: Expected 2 channels but got %u\n", num_channels);
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(num_channels == 2, "expected 2 channels for stereo layout");
 
   oar_destroy(oar);
-  printf("ck_channel_based test passed.\n\n");
-  return 0;
+  return TEST_PASS;
 }
 
-// Test case for ck_scene_based audio element type
-int test_scene_based_element() {
-  printf("Testing ck_scene_based audio element...\n");
+/* TC2: ck_scene_based audio element (1OA → 4 channels) */
+static int test_scene_based_element(void) {
+  TEST_START("TC2: scene-based element (1OA)");
 
-  oar_config_t config = create_default_oar_config();
+  oar_config_t config = create_config(ck_oar_layout_stereo, 1024, 48000);
   oar_t *oar = oar_create(&config);
-  if (oar == NULL) {
-    fprintf(stderr, "Error: Failed to create OAR object\n");
-    return -1;
-  }
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Error: Failed to add audio group, error code: %d\n",
-            group_id);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added successfully.\n", group_id);
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t element_config;
-  element_config.type = ck_scene_based;
-  element_config.sbc.order = ck_oar_1oa;
-  memset(&element_config.parameters, 0, sizeof(parameter_set_t));
+  oar_audio_element_config_t elem_cfg = create_scene_element_config(ck_oar_1oa);
+  int ret = oar_add_audio_element(oar, gid, 2, &elem_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
-  int ret = oar_add_audio_element(oar, group_id, 2, &element_config);
-  if (ret != 0) {
-    fprintf(stderr,
-            "Error: Failed to add audio element, expected 0 but got %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  // For 1st Order Ambisonics (1oa), we expect 4 channels (W, X, Y, Z)
   uint32_t num_channels = oar_get_number_of_audio_element_channels(oar, 2);
-  if (num_channels != 4) {
-    fprintf(stderr, "Error: Expected 4 channels but got %u\n", num_channels);
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(num_channels == 4, "expected 4 channels for 1OA");
 
   oar_destroy(oar);
-  printf("ck_scene_based test passed.\n\n");
-  return 0;
+  return TEST_PASS;
 }
 
-// Test case for ck_object_based audio element type
-int test_object_based_element() {
-  printf("Testing ck_object_based audio element...\n");
+/* TC3: ck_object_based audio element (1 object → 1 channel) */
+static int test_object_based_element(void) {
+  TEST_START("TC3: object-based element (1 object)");
 
-  oar_config_t config = create_default_oar_config();
+  oar_config_t config = create_config(ck_oar_layout_stereo, 1024, 48000);
   oar_t *oar = oar_create(&config);
-  if (oar == NULL) {
-    fprintf(stderr, "Error: Failed to create OAR object\n");
-    return -1;
-  }
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Error: Failed to add audio group, error code: %d\n",
-            group_id);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added successfully.\n", group_id);
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t element_config;
-  element_config.type = ck_object_based;
-  element_config.obc.num_objects = 1;  // Mono
-  memset(&element_config.parameters, 0, sizeof(parameter_set_t));
+  oar_audio_element_config_t elem_cfg = create_object_element_config(1);
+  int ret = oar_add_audio_element(oar, gid, 3, &elem_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
-  int ret = oar_add_audio_element(oar, group_id, 3, &element_config);
-  if (ret != 0) {
-    fprintf(stderr,
-            "Error: Failed to add audio element, expected 0 but got %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  // Object based is currently mono
   uint32_t num_channels = oar_get_number_of_audio_element_channels(oar, 3);
-  if (num_channels != 1) {
-    fprintf(stderr, "Error: Expected 1 channel but got %u\n", num_channels);
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(num_channels == 1, "expected 1 channel for 1 object");
 
   oar_destroy(oar);
-  printf("ck_object_based test passed.\n\n");
-  return 0;
+  return TEST_PASS;
 }
 
-// Test case for adding multiple elements of different types
-int test_multiple_element_types() {
-  printf("Testing multiple audio element types...\n");
-  // This test will focus on channel and scene based.
+/* TC4: Multiple elements of different types in separate groups */
+static int test_multiple_element_types(void) {
+  TEST_START("TC4: multiple element types");
 
-  oar_config_t config = create_default_oar_config();
+  oar_config_t config = create_config(ck_oar_layout_stereo, 1024, 48000);
   oar_t *oar = oar_create(&config);
-  if (oar == NULL) {
-    fprintf(stderr, "Error: Failed to create OAR object\n");
-    return -1;
-  }
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // Add channel-based element
-  oar_audio_element_config_t channel_config;
-  channel_config.type = ck_channel_based;
-  channel_config.cbc.layout = ck_oar_layout_mono;
-  memset(&channel_config.parameters, 0, sizeof(parameter_set_t));
+  /* Add channel-based element (mono) in group 1 */
+  oar_audio_element_config_t channel_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
+  int gid1 = oar_add_audio_group(oar);
+  TEST_ASSERT(gid1 >= 0, "oar_add_audio_group 1 failed");
 
-  int group_id1 = oar_add_audio_group(oar);
-  if (group_id1 < 0) {
-    fprintf(stderr, "Error: Failed to add audio group 1, error code: %d\n",
-            group_id1);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added for channel-based element.\n", group_id1);
+  int ret = oar_add_audio_element(oar, gid1, 1, &channel_cfg);
+  TEST_ASSERT(ret == 0, "add channel element failed");
 
-  int ret = oar_add_audio_element(oar, group_id1, 1, &channel_config);
-  if (ret != 0) {
-    fprintf(
-        stderr,
-        "Error: Failed to add channel audio element, expected 0 but got %d\n",
-        ret);
-    oar_destroy(oar);
-    return -1;
-  }
-  if (oar_get_number_of_audio_element_channels(oar, 1) != 1) {
-    fprintf(stderr,
-            "Error: Expected 1 channel for channel-based element but got %u\n",
-            oar_get_number_of_audio_element_channels(oar, 1));
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(oar_get_number_of_audio_element_channels(oar, 1) == 1,
+              "expected 1 channel for mono");
 
-  // Add scene-based element
-  oar_audio_element_config_t scene_config;
-  scene_config.type = ck_scene_based;
-  scene_config.sbc.order = ck_oar_zoa;  // Zero Order Ambisonics (mono)
-  memset(&scene_config.parameters, 0, sizeof(parameter_set_t));
+  /* Add scene-based element (ZOA = 1 channel) in group 2 */
+  oar_audio_element_config_t scene_cfg =
+      create_scene_element_config(ck_oar_zoa);
+  int gid2 = oar_add_audio_group(oar);
+  TEST_ASSERT(gid2 >= 0, "oar_add_audio_group 2 failed");
 
-  int group_id2 = oar_add_audio_group(oar);
-  if (group_id2 < 0) {
-    fprintf(stderr, "Error: Failed to add audio group 2, error code: %d\n",
-            group_id2);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added for scene-based element.\n", group_id2);
+  ret = oar_add_audio_element(oar, gid2, 2, &scene_cfg);
+  TEST_ASSERT(ret == 0, "add scene element failed");
 
-  ret = oar_add_audio_element(oar, group_id2, 2, &scene_config);
-  if (ret != 0) {
-    fprintf(stderr,
-            "Error: Failed to add scene audio element, expected 0 but got %d\n",
-            ret);
-    oar_destroy(oar);
-    return -1;
-  }
-  if (oar_get_number_of_audio_element_channels(oar, 2) !=
-      1) {  // ZOA is 1 channel
-    fprintf(stderr,
-            "Error: Expected 1 channel for scene-based element but got %u\n",
-            oar_get_number_of_audio_element_channels(oar, 2));
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(oar_get_number_of_audio_element_channels(oar, 2) == 1,
+              "expected 1 channel for ZOA");
 
   uint32_t num_elements = oar_get_number_of_audio_elements(oar);
-  if (num_elements != 2) {
-    fprintf(stderr, "Error: Expected 2 elements but got %u\n", num_elements);
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(num_elements == 2, "expected 2 elements");
 
   oar_destroy(oar);
-  printf("Multiple element types test passed.\n\n");
-  return 0;
+  return TEST_PASS;
 }
 
-int main() {
-  printf("Running audio_element_type_t tests...\n\n");
+/* --- Test table --------------------------------------------------------- */
 
-  int failed = 0;
-  failed |= test_channel_based_element() != 0;
-  failed |= test_scene_based_element() != 0;
-  failed |= test_object_based_element() != 0;
-  failed |= test_multiple_element_types() != 0;
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "channel-based element", test_channel_based_element),
+    TEST_ENTRY("TC2", "scene-based element", test_scene_based_element),
+    TEST_ENTRY("TC3", "object-based element", test_object_based_element),
+    TEST_ENTRY("TC4", "multiple element types", test_multiple_element_types),
+};
 
-  if (failed) {
-    fprintf(stderr, "audio_element_type_t tests FAILED.\n");
-    return -1;
-  }
-
-  printf("All audio_element_type_t tests completed successfully.\n");
-  return 0;
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }

--- a/tests/examples/test_channel_based_rendering.c
+++ b/tests/examples/test_channel_based_rendering.c
@@ -10,172 +10,80 @@
  * www.aomedia.org/license/patent.
  */
 
+/**
+ * @file test_channel_based_rendering.c
+ * @brief Test channel-based audio element rendering (mono → stereo).
+ *
+ * Test matrix:
+ *   TC1: Add a mono channel-based element, feed a 440 Hz sine, render, and
+ *        verify the output is non-silent.
+ */
 
-#include <math.h>  // For sine wave generation
+#include <math.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-// Include the OAR header
 #include "oar.h"
 #include "oar_base.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
-// Helper function to create a basic OAR config
-oar_config_t create_default_oar_config() {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_stereo;  // Render to stereo
-  config.samples_per_channel = 256;             // Smaller block for testing
-  config.sampling_rate = 48000;
-  return config;
-}
+static int test_channel_based_rendering(void) {
+  TEST_START("TC1: channel-based rendering (mono → stereo)");
 
-// Helper function to generate a simple sine wave for a given channel
-void generate_sine_wave(float* buffer, uint32_t samples, uint32_t num_channels,
-                        uint32_t channel_idx, float frequency,
-                        float sample_rate) {
-  for (uint32_t i = 0; i < samples; ++i) {
-    // Planar format: data for channel 0, then channel 1, etc.
-    buffer[channel_idx * samples + i] =
-        (float)sin(2.0 * M_PI * frequency * ((float)i / sample_rate));
-  }
-}
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-int main() {
-  printf("Running channel-based audio element rendering test...\n\n");
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_config_t oar_cfg = create_default_oar_config();
-  oar_t* oar = oar_create(&oar_cfg);
-  if (oar == NULL) {
-    fprintf(stderr, "Failed to create OAR object.\n");
-    return -1;
-  }
-  printf("OAR object created successfully.\n");
-
-  // Configure a channel-based audio element (e.g., mono)
-  oar_audio_element_config_t element_cfg;
-  element_cfg.type = ck_channel_based;
-  element_cfg.cbc.layout = ck_oar_layout_mono;  // Input is mono
-
-  memset(&element_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Failed to add audio group. Error code: %d\n", group_id);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added successfully.\n", group_id);
-
+  oar_audio_element_config_t element_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
   uint32_t element_id = 1;
-  int ret = oar_add_audio_element(oar, group_id, element_id, &element_cfg);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to add audio element. Error code: %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf(
-      "Channel-based audio element (ID: %d, Layout: mono) added "
-      "to group %d successfully.\n",
-      element_id, group_id);
+  int ret = oar_add_audio_element(oar, gid, element_id, &element_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
   uint32_t input_channels =
       oar_get_number_of_audio_element_channels(oar, element_id);
   uint32_t output_channels = oar_get_number_of_output_channels(oar);
   uint32_t samples_per_channel = oar_get_samples_per_channel(oar);
 
-  printf("Input channels: %u, Output channels: %u, Samples per channel: %u\n",
-         input_channels, output_channels, samples_per_channel);
-
-  // Prepare input audio data (planar format)
+  /* Prepare input audio data (planar format) */
   oar_audio_block_t input_data;
-  input_data.channels = input_channels;
-  input_data.samples_per_channel = samples_per_channel;
-  input_data.data =
-      (float*)malloc(input_channels * samples_per_channel * sizeof(float));
-  if (input_data.data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for input audio data.\n");
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(
+      alloc_audio_block(input_channels, samples_per_channel, &input_data) == 0,
+      "alloc_audio_block failed for input data");
 
-  // Generate a simple sine wave for the mono input
-  generate_sine_wave(input_data.data, samples_per_channel, input_channels, 0,
-                     440.0, (float)oar_cfg.sampling_rate);
-  printf("Generated %u samples of 440Hz sine wave for mono input.\n",
-         samples_per_channel);
+  generate_sine_channel(input_data.data, samples_per_channel, input_channels, 0,
+                        440.0f, (float)oar_cfg.sampling_rate);
 
-  // Update the audio element with the generated data
   ret = oar_update_audio_element_data(oar, element_id, &input_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to update audio element data. Error code: %d\n",
-            ret);
-    free(input_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio element data updated successfully.\n");
-
-  // Prepare output audio data (planar format)
-  oar_audio_block_t output_data;
-  output_data.channels = output_channels;  // Should be stereo as per oar_config
-  output_data.samples_per_channel = samples_per_channel;
-  output_data.data =
-      (float*)malloc(output_channels * samples_per_channel * sizeof(float));
-  if (output_data.data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for output audio data.\n");
-    free(input_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  // Initialize output to silence
-  memset(output_data.data, 0,
-         output_channels * samples_per_channel * sizeof(float));
-
-  // Perform rendering
-  printf("Rendering audio...\n");
-  ret = oar_render(oar, &output_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to render audio. Error code: %d\n", ret);
-    free(input_data.data);
-    free(output_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio rendered successfully to %u channels.\n", output_data.channels);
-
-  // Here, one would typically save the output_data to a file or play it.
-  // For this test, we'll just verify that the output is not all silence.
-  int is_silent = 1;
-  for (uint32_t i = 0; i < output_channels * samples_per_channel; ++i) {
-    if (fabs(output_data.data[i]) > 1e-9) {  // Check if not close to zero
-      is_silent = 0;
-      break;
-    }
-  }
-
-  if (is_silent) {
-    printf("Warning: Rendered output is silent.\n");
-  } else {
-    printf("Rendered output contains audio.\n");
-  }
-
-  // Print a few samples from the first output channel for inspection
-  printf("First 5 samples of output channel 0:\n");
-  for (int i = 0; i < 5; ++i) {
-    printf("  %f\n", output_data.data[i]);
-  }
-
-  // Cleanup
   free(input_data.data);
-  free(output_data.data);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_data failed");
+
+  /* Render and verify non-silent output */
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(output_channels, samples_per_channel, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(output.data);
   oar_destroy(oar);
 
-  printf("\nChannel-based rendering test completed.\n");
-  return 0;
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
+}
+
+/* --- Test table --------------------------------------------------------- */
+
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "channel-based rendering", test_channel_based_rendering),
+};
+
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }

--- a/tests/examples/test_framework.c
+++ b/tests/examples/test_framework.c
@@ -6,7 +6,7 @@
  * License was not distributed with this source code in the LICENSE file, you
  * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
  * Alliance for Open Media Patent License 1.0 was not distributed with this
- * source code in the PATENTS file, you can obtain it at
+ * source code in the LICENSE file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
 
@@ -65,7 +65,20 @@ static int run_test_in_child(test_entry_t *tests, int num_tests,
 
   /* Parent: wait for the child and interpret the exit status. */
   int status = 0;
-  waitpid(pid, &status, 0);
+  int r;
+  /**
+   * Retry waitpid if interrupted by a signal (EINTR). The loop exits when:
+   * - waitpid succeeds (r >= 0), or
+   * - waitpid fails with an error other than EINTR (e.g. ECHILD, EINVAL).
+   * This cannot deadlock: the child process will eventually terminate
+   * (exit, crash, or SIGKILL), so waitpid will ultimately succeed.
+   * */
+  while ((r = waitpid(pid, &status, 0)) < 0 && errno == EINTR) {
+  }
+  if (r < 0) {
+    perror("waitpid");
+    return TEST_FAIL;
+  }
 
   if (WIFEXITED(status)) {
     int exit_code = WEXITSTATUS(status);

--- a/tests/examples/test_framework.h
+++ b/tests/examples/test_framework.h
@@ -6,7 +6,7 @@
  * License was not distributed with this source code in the LICENSE file, you
  * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
  * Alliance for Open Media Patent License 1.0 was not distributed with this
- * source code in the PATENTS file, you can obtain it at
+ * source code in the LICENSE file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
 

--- a/tests/examples/test_helpers.c
+++ b/tests/examples/test_helpers.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+#include "test_helpers.h"
+
+#include <math.h>
+#include <stdlib.h>
+
+/* --- Config helpers ----------------------------------------------------- */
+
+oar_config_t create_config(oar_layout_t layout, uint32_t samples_per_channel,
+                           uint32_t sampling_rate) {
+  oar_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.target_layout = layout;
+  config.samples_per_channel = samples_per_channel;
+  config.sampling_rate = sampling_rate;
+  return config;
+}
+
+/* --- Signal generation -------------------------------------------------- */
+
+void generate_sine(float *buffer, uint32_t samples, float freq, float rate) {
+  for (uint32_t i = 0; i < samples; ++i) {
+    buffer[i] = (float)sin(2.0 * M_PI * freq * ((float)i / rate));
+  }
+}
+
+void generate_sine_channel(float *buffer, uint32_t samples, uint32_t channels,
+                           uint32_t ch_idx, float freq, float rate) {
+  (void)channels; /* channels unused; ch_idx * samples is the planar offset */
+  for (uint32_t i = 0; i < samples; ++i) {
+    buffer[ch_idx * samples + i] =
+        (float)sin(2.0 * M_PI * freq * ((float)i / rate));
+  }
+}
+
+/* --- Element config helpers --------------------------------------------- */
+
+oar_audio_element_config_t create_object_element_config(int num_objects) {
+  oar_audio_element_config_t cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.type = ck_object_based;
+  cfg.obc.num_objects = num_objects;
+  return cfg;
+}
+
+oar_audio_element_config_t create_channel_element_config(oar_layout_t layout) {
+  oar_audio_element_config_t cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.type = ck_channel_based;
+  cfg.cbc.layout = layout;
+  return cfg;
+}
+
+oar_audio_element_config_t create_scene_element_config(oar_hoa_t order) {
+  oar_audio_element_config_t cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.type = ck_scene_based;
+  cfg.sbc.order = order;
+  return cfg;
+}
+
+/* --- Metadata helpers --------------------------------------------------- */
+
+oar_metadata_t *create_object_metadata(const polar_t *positions,
+                                       uint32_t num_objects,
+                                       uint32_t duration) {
+  if (num_objects == 0 || num_objects > def_max_number_of_objects ||
+      !positions) {
+    return NULL;
+  }
+
+  oar_metadata_t *metadata = (oar_metadata_t *)malloc(sizeof(oar_metadata_t));
+  if (!metadata) return NULL;
+
+  memset(metadata, 0, sizeof(*metadata));
+  metadata->type = ck_metadata_object_positions;
+  metadata->duration = (int)duration;
+  metadata->object_positions.param_type = ck_param_constant;
+  metadata->object_positions.position_type = ck_polar;
+  metadata->object_positions.num_objects = num_objects;
+
+  for (uint32_t i = 0; i < num_objects; ++i) {
+    metadata->object_positions.polar_positions[i].azimuth =
+        positions[i].azimuth;
+    metadata->object_positions.polar_positions[i].elevation =
+        positions[i].elevation;
+    metadata->object_positions.polar_positions[i].distance =
+        positions[i].distance;
+  }
+
+  return metadata;
+}
+
+/* --- Output helpers ------------------------------------------------------ */
+
+int is_output_non_silent(const float *data, uint32_t count) {
+  for (uint32_t i = 0; i < count; ++i) {
+    if (fabsf(data[i]) > 1e-9f) return 1;
+  }
+  return 0;
+}
+
+int alloc_audio_block(uint32_t channels, uint32_t samples_per_channel,
+                      oar_audio_block_t *output) {
+  memset(output, 0, sizeof(*output));
+  output->channels = channels;
+  output->samples_per_channel = samples_per_channel;
+  output->data = (float *)calloc(channels * samples_per_channel, sizeof(float));
+  return output->data ? 0 : -1;
+}
+
+int render_and_check_non_silent(oar_t *oar, oar_audio_block_t *output) {
+  memset(output->data, 0,
+         output->channels * output->samples_per_channel * sizeof(float));
+  if (oar_render(oar, output) != 0) return -1;
+  uint32_t total = output->channels * output->samples_per_channel;
+  if (!is_output_non_silent(output->data, total)) return -1;
+  return 0;
+}

--- a/tests/examples/test_helpers.c
+++ b/tests/examples/test_helpers.c
@@ -44,6 +44,16 @@ void generate_sine_channel(float *buffer, uint32_t samples, uint32_t channels,
   }
 }
 
+void generate_dual_tone_stimulus(float *buffer, uint32_t samples,
+                                 float sample_rate, float freq_low,
+                                 float freq_high) {
+  for (uint32_t i = 0; i < samples; ++i) {
+    float t = (float)i / sample_rate;
+    buffer[i] = 0.45f * (float)sin(2.0 * M_PI * freq_low * t) +
+                0.45f * (float)sin(2.0 * M_PI * freq_high * t);
+  }
+}
+
 /* --- Element config helpers --------------------------------------------- */
 
 oar_audio_element_config_t create_object_element_config(int num_objects) {

--- a/tests/examples/test_helpers.h
+++ b/tests/examples/test_helpers.h
@@ -49,6 +49,13 @@ void generate_sine(float *buffer, uint32_t samples, float freq, float rate);
 void generate_sine_channel(float *buffer, uint32_t samples, uint32_t channels,
                            uint32_t ch_idx, float freq, float rate);
 
+/** Generate a composite dual-tone test stimulus into a single-channel buffer.
+ *  The broad-band content ensures frequency-dependent effects (e.g.
+ *  head-shadow ILD) are exercised. */
+void generate_dual_tone_stimulus(float *buffer, uint32_t samples,
+                                 float sample_rate, float freq_low,
+                                 float freq_high);
+
 /* --- Element config helpers --------------------------------------------- */
 
 /** Create a zeroed object-based element config with num_objects objects. */

--- a/tests/examples/test_helpers.h
+++ b/tests/examples/test_helpers.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/**
+ * @file test_helpers.h
+ * @brief Shared test utility functions for OAR test suites.
+ *
+ * Provides signal generation, silence detection, config/element creation,
+ * and output block helpers that are common across multiple test files.
+ *
+ * Depends on oar.h (and transitively oar_base.h, oar_metadata.h).
+ */
+
+#ifndef OAR_TEST_HELPERS_H
+#define OAR_TEST_HELPERS_H
+
+#include <stdint.h>
+#include <string.h>
+
+#include "oar.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/* --- Config helpers ----------------------------------------------------- */
+
+/** Create an oar_config_t with the given target layout, samples_per_channel,
+ *  and sampling_rate. */
+oar_config_t create_config(oar_layout_t layout, uint32_t samples_per_channel,
+                           uint32_t sampling_rate);
+
+/* --- Signal generation -------------------------------------------------- */
+
+/** Write a sine wave into buffer[0..samples-1] (single channel). */
+void generate_sine(float *buffer, uint32_t samples, float freq, float rate);
+
+/** Write a sine wave into one channel of a planar multi-channel buffer.
+ *  Writes to buffer[ch_idx * samples .. (ch_idx + 1) * samples - 1]. */
+void generate_sine_channel(float *buffer, uint32_t samples, uint32_t channels,
+                           uint32_t ch_idx, float freq, float rate);
+
+/* --- Element config helpers --------------------------------------------- */
+
+/** Create a zeroed object-based element config with num_objects objects. */
+oar_audio_element_config_t create_object_element_config(int num_objects);
+
+/** Create a zeroed channel-based element config with the given layout. */
+oar_audio_element_config_t create_channel_element_config(oar_layout_t layout);
+
+/** Create a zeroed scene-based element config with the given ambisonic order.
+ */
+oar_audio_element_config_t create_scene_element_config(oar_hoa_t order);
+
+/* --- Metadata helpers --------------------------------------------------- */
+
+/** Create object position metadata (heap-allocated, caller must free).
+ *  @param positions   Array of polar positions.
+ *  @param num_objects Number of objects (1..def_max_number_of_objects).
+ *  @param duration    Metadata duration in samples.
+ *  @return NULL on failure. */
+oar_metadata_t *create_object_metadata(const polar_t *positions,
+                                       uint32_t num_objects, uint32_t duration);
+
+/* --- Output helpers ------------------------------------------------------ */
+
+/** Check whether data contains any non-zero samples (threshold 1e-9f).
+ *  @return 1 if non-silent, 0 if silent. */
+int is_output_non_silent(const float *data, uint32_t count);
+
+/** Allocate a zero-initialised audio block (channels, samples_per_channel,
+ *  and data buffer all set). Caller must free output->data.
+ *  @return 0 on success, -1 on allocation failure. */
+int alloc_audio_block(uint32_t channels, uint32_t samples_per_channel,
+                      oar_audio_block_t *output);
+
+/** Zero the output buffer, render, and verify the output is non-silent.
+ *  @return 0 on success, -1 on render failure or silent output. */
+int render_and_check_non_silent(oar_t *oar, oar_audio_block_t *output);
+
+#endif /* OAR_TEST_HELPERS_H */

--- a/tests/examples/test_hoa_lfe_rendering.c
+++ b/tests/examples/test_hoa_lfe_rendering.c
@@ -10,62 +10,63 @@
  * www.aomedia.org/license/patent.
  */
 
-// Regression test for the 120 Hz LFE low-pass filter applied when rendering
-// HOA to an LFE-bearing loudspeaker layout (requires OAR_ENABLE_HOA_LFE).
-//
-// The filter coefficients were previously computed for a hardcoded 48 kHz
-// rate regardless of oar_config_t.sampling_rate, so at 96 kHz the effective
-// cutoff landed at ~240 Hz and the LFE channel passed twice the intended
-// bandwidth. The LFE level for a given tone must be invariant to the output
-// sampling rate, and tones well above the cutoff must be attenuated.
+/**
+ * @file test_hoa_lfe_rendering.c
+ * @brief Regression test for the 120 Hz LFE low-pass filter applied when
+ *        rendering HOA to an LFE-bearing loudspeaker layout (requires
+ *        OAR_ENABLE_HOA_LFE).
+ *
+ * The filter coefficients were previously computed for a hardcoded 48 kHz
+ * rate regardless of oar_config_t.sampling_rate, so at 96 kHz the effective
+ * cutoff landed at ~240 Hz and the LFE channel passed twice the intended
+ * bandwidth. The LFE level for a given tone must be invariant to the output
+ * sampling rate, and tones well above the cutoff must be attenuated.
+ *
+ * Test matrix:
+ *   TC1: LFE level for a 200 Hz tone must be invariant to output sampling rate
+ *        (48k vs 96k vs 44.1k — ratio within ±5%).
+ *   TC2: LFE low-pass must attenuate 1 kHz at least 25 dB below 200 Hz at
+ *        44.1k, 48k, and 96k.
+ */
 
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 #include "oar.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
-// Channel order of ck_oar_layout_51 is L R C LFE Ls Rs.
+/* Channel order of ck_oar_layout_51 is L R C LFE Ls Rs. */
 #define LFE_CHANNEL_INDEX 3
 #define BLOCK_SIZE 256
-// Enough blocks for the IIR filter to reach steady state at both rates.
+/* Enough blocks for the IIR filter to reach steady state at both rates. */
 #define NUM_BLOCKS 40
 
-// Renders a sine of `tone_hz` on the W channel of a 1OA scene element to a
-// 5.1 layout at `sampling_rate`, and returns the steady-state RMS of the LFE
-// output channel (measured over the last quarter of the blocks). Returns a
-// negative value on setup failure.
+/* Renders a sine of `tone_hz` on the W channel of a 1OA scene element to a
+ * 5.1 layout at `sampling_rate`, and returns the steady-state RMS of the LFE
+ * output channel (measured over the last quarter of the blocks). Returns a
+ * negative value on setup failure. */
 static double render_lfe_rms(uint32_t sampling_rate, double tone_hz) {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_51;
-  config.samples_per_channel = BLOCK_SIZE;
-  config.sampling_rate = sampling_rate;
+  oar_config_t config =
+      create_config(ck_oar_layout_51, BLOCK_SIZE, sampling_rate);
 
   oar_t *oar = oar_create(&config);
-  if (oar == NULL) {
-    fprintf(stderr, "Failed to create OAR object at %u Hz.\n", sampling_rate);
-    return -1.0;
-  }
+  if (oar == NULL) return -1.0;
 
-  oar_audio_element_config_t element_cfg;
-  memset(&element_cfg, 0, sizeof(element_cfg));
-  element_cfg.type = ck_scene_based;
-  element_cfg.sbc.order = ck_oar_1oa;
+  oar_audio_element_config_t element_cfg =
+      create_scene_element_config(ck_oar_1oa);
 
   int group_id = oar_add_audio_group(oar);
   if (group_id < 0) {
-    fprintf(stderr, "Failed to add audio group.\n");
     oar_destroy(oar);
     return -1.0;
   }
+
   const uint32_t element_id = 1;
   if (oar_add_audio_element(oar, group_id, element_id, &element_cfg) != 0) {
-    fprintf(stderr, "Failed to add audio element.\n");
     oar_destroy(oar);
     return -1.0;
   }
@@ -74,43 +75,40 @@ static double render_lfe_rms(uint32_t sampling_rate, double tone_hz) {
       oar_get_number_of_audio_element_channels(oar, element_id);
   const uint32_t out_channels = oar_get_number_of_output_channels(oar);
 
-  float *input = (float *)calloc((size_t)in_channels * BLOCK_SIZE,
-                                 sizeof(float));
-  float *output = (float *)calloc((size_t)out_channels * BLOCK_SIZE,
-                                  sizeof(float));
+  float *input =
+      (float *)calloc((size_t)in_channels * BLOCK_SIZE, sizeof(float));
+  float *output =
+      (float *)calloc((size_t)out_channels * BLOCK_SIZE, sizeof(float));
   if (input == NULL || output == NULL) {
-    fprintf(stderr, "Allocation failure.\n");
     free(input);
     free(output);
     oar_destroy(oar);
     return -1.0;
   }
 
-  oar_audio_block_t input_block = {
-      .channels = in_channels, .samples_per_channel = BLOCK_SIZE,
-      .data = input};
-  oar_audio_block_t output_block = {
-      .channels = out_channels, .samples_per_channel = BLOCK_SIZE,
-      .data = output};
+  oar_audio_block_t input_block = {.channels = in_channels,
+                                   .samples_per_channel = BLOCK_SIZE,
+                                   .data = input};
+  oar_audio_block_t output_block = {.channels = out_channels,
+                                    .samples_per_channel = BLOCK_SIZE,
+                                    .data = output};
 
   double sum_squares = 0.0;
   size_t num_measured = 0;
   for (int block = 0; block < NUM_BLOCKS; ++block) {
-    // Continuous-phase tone on W (channel 0); other channels stay silent.
+    /* Continuous-phase tone on W (channel 0); other channels stay silent. */
     for (int i = 0; i < BLOCK_SIZE; ++i) {
-      const double t =
-          (double)(block * BLOCK_SIZE + i) / (double)sampling_rate;
+      const double t = (double)(block * BLOCK_SIZE + i) / (double)sampling_rate;
       input[i] = (float)sin(2.0 * M_PI * tone_hz * t);
     }
     if (oar_update_audio_element_data(oar, element_id, &input_block) != 0 ||
         oar_render(oar, &output_block) != 0) {
-      fprintf(stderr, "Render failure at %u Hz.\n", sampling_rate);
       free(input);
       free(output);
       oar_destroy(oar);
       return -1.0;
     }
-    if (block >= (3 * NUM_BLOCKS) / 4) {  // Steady state only.
+    if (block >= (3 * NUM_BLOCKS) / 4) { /* Steady state only. */
       const float *lfe = output + (size_t)LFE_CHANNEL_INDEX * BLOCK_SIZE;
       for (int i = 0; i < BLOCK_SIZE; ++i) {
         sum_squares += (double)lfe[i] * lfe[i];
@@ -125,68 +123,72 @@ static double render_lfe_rms(uint32_t sampling_rate, double tone_hz) {
   return sqrt(sum_squares / (double)num_measured);
 }
 
-int main() {
-  printf("Running HOA LFE low-pass sampling-rate test...\n\n");
-  int failures = 0;
+/* TC1: LFE level for a 200 Hz tone must be invariant to output sampling rate.
+ */
+static int test_lfe_level_sampling_rate_invariant(void) {
+  TEST_START("TC1: LFE level invariant to sampling rate");
 
-  // A tone near the 120 Hz cutoff, where a mis-scaled cutoff (240 Hz at a
-  // 96 kHz output rate with the old hardcoded coefficients) changes the
-  // level the most.
+  /* A tone near the 120 Hz cutoff, where a mis-scaled cutoff (240 Hz at a
+   * 96 kHz output rate with the old hardcoded coefficients) changes the
+   * level the most. */
   const double kProbeToneHz = 200.0;
   const double rms_48k = render_lfe_rms(48000, kProbeToneHz);
   const double rms_96k = render_lfe_rms(96000, kProbeToneHz);
   const double rms_44k = render_lfe_rms(44100, kProbeToneHz);
-  if (rms_48k <= 0.0 || rms_96k <= 0.0 || rms_44k <= 0.0) {
-    fprintf(stderr, "FAIL: setup/render failed or LFE channel is silent.\n");
-    return -1;
-  }
-  printf("LFE RMS for %.0f Hz tone: 44.1k=%.6f 48k=%.6f 96k=%.6f\n",
-         kProbeToneHz, rms_44k, rms_48k, rms_96k);
 
-  // The LFE level must be invariant to the output sampling rate. With the
-  // hardcoded-48k bug, the measured 96 kHz ratio is 2.697x.
+  TEST_ASSERT(rms_48k > 0.0, "48k render failed or LFE silent");
+  TEST_ASSERT(rms_96k > 0.0, "96k render failed or LFE silent");
+  TEST_ASSERT(rms_44k > 0.0, "44.1k render failed or LFE silent");
+
+  /* The LFE level must be invariant to the output sampling rate. With the
+   * hardcoded-48k bug, the measured 96 kHz ratio is 2.697x. */
   const double ratio_96k = rms_96k / rms_48k;
   const double ratio_44k = rms_44k / rms_48k;
-  if (fabs(ratio_96k - 1.0) > 0.05 || fabs(ratio_44k - 1.0) > 0.05) {
-    fprintf(stderr,
-            "FAIL: LFE level depends on the sampling rate "
-            "(96k/48k=%.3f, 44.1k/48k=%.3f, expected 1.0 +-0.05).\n",
-            ratio_96k, ratio_44k);
-    failures++;
-  } else {
-    printf("PASS: LFE level is invariant to the sampling rate "
-           "(96k/48k=%.3f, 44.1k/48k=%.3f).\n",
-           ratio_96k, ratio_44k);
-  }
 
-  // The filter must attenuate well above the 120 Hz cutoff at every rate:
-  // measured, a 1 kHz tone sits ~29 dB below the 200 Hz tone. With the
-  // hardcoded-48k bug, the 96 kHz attenuation degraded to ~25.5 dB.
+  TEST_ASSERT(
+      fabs(ratio_96k - 1.0) <= 0.05,
+      "LFE level depends on sampling rate (96k/48k ratio out of range)");
+  TEST_ASSERT(
+      fabs(ratio_44k - 1.0) <= 0.05,
+      "LFE level depends on sampling rate (44.1k/48k ratio out of range)");
+
+  return TEST_PASS;
+}
+
+/* TC2: LFE low-pass must attenuate 1 kHz at least 25 dB below 200 Hz. */
+static int test_lfe_lowpass_attenuation(void) {
+  TEST_START("TC2: LFE low-pass attenuation at 1 kHz");
+
+  /* The filter must attenuate well above the 120 Hz cutoff at every rate:
+   * measured, a 1 kHz tone sits ~29 dB below the 200 Hz tone. With the
+   * hardcoded-48k bug, the 96 kHz attenuation degraded to ~25.5 dB. */
+  const double kLowToneHz = 200.0;
   const double kHighToneHz = 1000.0;
+  const uint32_t rates[3] = {44100, 48000, 96000};
+
   for (int i = 0; i < 3; ++i) {
-    const uint32_t rates[3] = {44100, 48000, 96000};
-    const double rms_low = render_lfe_rms(rates[i], kProbeToneHz);
+    const double rms_low = render_lfe_rms(rates[i], kLowToneHz);
     const double rms_high = render_lfe_rms(rates[i], kHighToneHz);
-    if (rms_low <= 0.0 || rms_high <= 0.0) {
-      fprintf(stderr, "FAIL: render failed at %u Hz.\n", rates[i]);
-      return -1;
-    }
+
+    TEST_ASSERT(rms_low > 0.0, "low-tone render failed");
+    TEST_ASSERT(rms_high > 0.0, "high-tone render failed");
+
     const double attenuation_db = 20.0 * log10(rms_high / rms_low);
-    printf("1 kHz vs 200 Hz LFE level at %u Hz: %.1f dB\n", rates[i],
-           attenuation_db);
-    if (attenuation_db > -25.0) {
-      fprintf(stderr,
-              "FAIL: insufficient LFE low-pass attenuation at %u Hz "
-              "(%.1f dB, expected < -25 dB).\n",
-              rates[i], attenuation_db);
-      failures++;
-    }
+    TEST_ASSERT(attenuation_db <= -25.0,
+                "insufficient LFE low-pass attenuation");
   }
 
-  if (failures > 0) {
-    fprintf(stderr, "\nHOA LFE rendering test FAILED (%d).\n", failures);
-    return -1;
-  }
-  printf("\nHOA LFE rendering test completed successfully.\n");
-  return 0;
+  return TEST_PASS;
+}
+
+/* --- Test table --------------------------------------------------------- */
+
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "LFE level sampling-rate invariant",
+               test_lfe_level_sampling_rate_invariant),
+    TEST_ENTRY("TC2", "LFE low-pass attenuation", test_lfe_lowpass_attenuation),
+};
+
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }

--- a/tests/examples/test_metadata_unit_processing.c
+++ b/tests/examples/test_metadata_unit_processing.c
@@ -59,20 +59,6 @@
  * for them to count as "different". */
 #define TEST_MIN_RELATIVE_DIFF 0.05
 
-/* --- Signal generation helpers ------------------------------------------ */
-
-/* Head-shadow ILD is weak below ~1.5 kHz, so a pure 440 Hz tone would make
- * the interaural asymmetry checks in TC13/TC14 fragile. Use a stimulus with
- * both low- and high-frequency content instead. */
-static void generate_test_stimulus(float *buffer, uint32_t samples,
-                                   float sample_rate) {
-  for (uint32_t i = 0; i < samples; ++i) {
-    float t = (float)i / sample_rate;
-    buffer[i] = 0.45f * (float)sin(2.0 * M_PI * 440.0 * t) +
-                0.45f * (float)sin(2.0 * M_PI * 3500.0 * t);
-  }
-}
-
 /* --- Metadata helpers --------------------------------------------------- */
 
 static int submit_position(oar_t *oar, uint32_t element_id, float azimuth,
@@ -171,8 +157,8 @@ static int submit_stimulus_block(oar_t *oar, uint32_t element_id,
   if (alloc_audio_block(channels, samples, &block) != 0) return -1;
 
   for (uint32_t c = 0; c < channels; ++c) {
-    generate_test_stimulus(block.data + c * samples, samples,
-                           (float)TEST_SAMPLING_RATE);
+    generate_dual_tone_stimulus(block.data + c * samples, samples,
+                                (float)TEST_SAMPLING_RATE, 440.0f, 3500.0f);
   }
 
   int ret = oar_update_audio_element_data(oar, element_id, &block);

--- a/tests/examples/test_metadata_unit_processing.c
+++ b/tests/examples/test_metadata_unit_processing.c
@@ -4,9 +4,9 @@
  * This source code is subject to the terms of the BSD 3-Clause Clear License
  * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
  * License was not distributed with this source code in the LICENSE file, you
- * can obtain it at www.aomedia.org/license/software-license/bsd-3-c. If the
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
  * Alliance for Open Media Patent License 1.0 was not distributed with this
- * source code in the PATENTS file, you can obtain it at
+ * source code in the LICENSE file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
 
@@ -33,29 +33,17 @@
  *   TC15: binaural, input block smaller than frame → rejected, no abort
  *   TC16: binaural, mismatched block sizes across elements → rejected
  *   TC17: binaural, two elements rendered simultaneously → independent
- * positions
+ *         positions
  */
 
-#include <errno.h>
 #include <math.h>
-#include <signal.h>
-#include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef _WIN32
-#include <sys/wait.h>
-#include <unistd.h>
-#else
-#include <process.h>
-#include <windows.h>
-#endif
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 #include "oar.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
 #define TEST_SAMPLING_RATE 48000
 #define TEST_SAMPLES_PER_CHANNEL 512
@@ -71,101 +59,7 @@
  * for them to count as "different". */
 #define TEST_MIN_RELATIVE_DIFF 0.05
 
-static void generate_sine_wave(float *buffer, uint32_t samples, float frequency,
-                               float sample_rate) {
-  for (uint32_t i = 0; i < samples; ++i) {
-    buffer[i] = (float)sin(2.0 * M_PI * frequency * ((float)i / sample_rate));
-  }
-}
-
-static oar_metadata_t *create_position_metadata(polar_t position,
-                                                uint32_t duration) {
-  oar_metadata_t *metadata = (oar_metadata_t *)malloc(sizeof(oar_metadata_t));
-  if (!metadata) return NULL;
-
-  metadata->type = ck_metadata_object_positions;
-  metadata->duration = (int)duration;
-  metadata->object_positions.param_type = ck_param_constant;
-  metadata->object_positions.position_type = ck_polar;
-  metadata->object_positions.num_objects = 1;
-  metadata->object_positions.polar_positions[0].azimuth = position.azimuth;
-  metadata->object_positions.polar_positions[0].elevation = position.elevation;
-  metadata->object_positions.polar_positions[0].distance = position.distance;
-
-  return metadata;
-}
-
-static int is_output_non_silent(const float *data, uint32_t count) {
-  for (uint32_t i = 0; i < count; ++i) {
-    if (fabs(data[i]) > 1e-9f) return 1;
-  }
-  return 0;
-}
-
-/* Unified helper: adds an object-based element, fills all input channels with
- * a sine wave, optionally attaches a default position metadata, and submits
- * the data. Replaces the former add_object_element_and_data and
- * add_object_element_without_position. */
-static int add_object_element(oar_t *oar, uint32_t *out_channels,
-                              float **out_input_data, int add_position) {
-  int gid = oar_add_audio_group(oar);
-  if (gid < 0) return -1;
-
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_object_based;
-  elem_cfg.obc.num_objects = 1;
-  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  if (oar_add_audio_element(oar, gid, TEST_ELEMENT_ID, &elem_cfg) != 0)
-    return -1;
-
-  uint32_t input_channels =
-      oar_get_number_of_audio_element_channels(oar, TEST_ELEMENT_ID);
-
-  oar_audio_block_t input_data;
-  input_data.channels = input_channels;
-  input_data.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  input_data.data = (float *)malloc(input_channels * TEST_SAMPLES_PER_CHANNEL *
-                                    sizeof(float));
-  if (!input_data.data) return -1;
-
-  /* Fill all input channels (not just channel 0) */
-  for (uint32_t ch = 0; ch < input_channels; ch++) {
-    generate_sine_wave(input_data.data + ch * TEST_SAMPLES_PER_CHANNEL,
-                       TEST_SAMPLES_PER_CHANNEL, 440.0f,
-                       (float)TEST_SAMPLING_RATE);
-  }
-
-  if (oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data) != 0) {
-    fprintf(stderr, "FAIL: oar_update_audio_element_data failed.\n");
-    free(input_data.data);
-    return -1;
-  }
-
-  if (add_position) {
-    polar_t position = {30.0f, 0.0f, 1.0f};
-    oar_metadata_t *pos_meta =
-        create_position_metadata(position, TEST_SAMPLES_PER_CHANNEL);
-    if (!pos_meta) {
-      fprintf(stderr, "FAIL: create_position_metadata returned NULL.\n");
-      free(input_data.data);
-      return -1;
-    }
-    int ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, pos_meta);
-    free(pos_meta);
-    if (ret != 0) {
-      fprintf(stderr, "FAIL: oar_update_audio_element_metadata failed (%d).\n",
-              ret);
-      free(input_data.data);
-      return -1;
-    }
-  }
-
-  *out_channels = oar_get_number_of_output_channels(oar);
-  *out_input_data = input_data.data;
-  return 0;
-}
+/* --- Signal generation helpers ------------------------------------------ */
 
 /* Head-shadow ILD is weak below ~1.5 kHz, so a pure 440 Hz tone would make
  * the interaural asymmetry checks in TC13/TC14 fragile. Use a stimulus with
@@ -179,57 +73,12 @@ static void generate_test_stimulus(float *buffer, uint32_t samples,
   }
 }
 
-static int add_object_element_to_group(oar_t *oar, int gid,
-                                       uint32_t element_id) {
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_object_based;
-  elem_cfg.obc.num_objects = 1;
-  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  return oar_add_audio_element(oar, gid, element_id, &elem_cfg);
-}
-
-/* Like add_object_element_to_group but allows specifying num_objects (1-2). */
-static int add_object_element_to_group_n(oar_t *oar, int gid,
-                                         uint32_t element_id, int num_objects) {
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_object_based;
-  elem_cfg.obc.num_objects = num_objects;
-  memset(&elem_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  return oar_add_audio_element(oar, gid, element_id, &elem_cfg);
-}
-
-/* Submit a stimulus block of the given size for one element, filling every
- * input channel. The renderer copies the block, so the buffer is freed here.
- * Returns the oar_update_audio_element_data result. */
-static int submit_stimulus_block(oar_t *oar, uint32_t element_id,
-                                 uint32_t samples) {
-  uint32_t channels = oar_get_number_of_audio_element_channels(oar, element_id);
-  if (channels == 0) return -1;
-
-  oar_audio_block_t block;
-  block.channels = channels;
-  block.samples_per_channel = samples;
-  block.data = (float *)malloc(channels * samples * sizeof(float));
-  if (!block.data) return -1;
-
-  for (uint32_t c = 0; c < channels; ++c) {
-    generate_test_stimulus(block.data + c * samples, samples,
-                           (float)TEST_SAMPLING_RATE);
-  }
-
-  int ret = oar_update_audio_element_data(oar, element_id, &block);
-  free(block.data);
-  return ret;
-}
+/* --- Metadata helpers --------------------------------------------------- */
 
 static int submit_position(oar_t *oar, uint32_t element_id, float azimuth,
                            uint32_t duration) {
   polar_t position = {azimuth, 0.0f, 1.0f};
-  oar_metadata_t *meta = create_position_metadata(position, duration);
+  oar_metadata_t *meta = create_object_metadata(&position, 1, duration);
   if (!meta) return -1;
   int ret = oar_update_audio_element_metadata(oar, element_id, meta);
   free(meta);
@@ -252,6 +101,87 @@ static int submit_position_dual(oar_t *oar, uint32_t element_id, float az1,
   return oar_update_audio_element_metadata(oar, element_id, &meta);
 }
 
+/* --- Element setup helpers ----------------------------------------------- */
+
+static int add_object_element_to_group(oar_t *oar, int gid, uint32_t element_id,
+                                       int num_objects) {
+  oar_audio_element_config_t elem_cfg =
+      create_object_element_config(num_objects);
+  return oar_add_audio_element(oar, gid, element_id, &elem_cfg);
+}
+
+/* Adds an object-based element (num_objects=1), fills all input channels with
+ * a sine wave, optionally attaches a default position metadata, and submits
+ * the data. Returns 0 on success; caller frees *out_input_data. */
+static int add_object_element(oar_t *oar, uint32_t *out_channels,
+                              float **out_input_data, int add_position) {
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0) return -1;
+
+  if (add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) != 0) return -1;
+
+  uint32_t input_channels =
+      oar_get_number_of_audio_element_channels(oar, TEST_ELEMENT_ID);
+
+  oar_audio_block_t input_data;
+  if (alloc_audio_block(input_channels, TEST_SAMPLES_PER_CHANNEL,
+                        &input_data) != 0)
+    return -1;
+
+  for (uint32_t ch = 0; ch < input_channels; ch++) {
+    generate_sine(input_data.data + ch * TEST_SAMPLES_PER_CHANNEL,
+                  TEST_SAMPLES_PER_CHANNEL, 440.0f, (float)TEST_SAMPLING_RATE);
+  }
+
+  if (oar_update_audio_element_data(oar, TEST_ELEMENT_ID, &input_data) != 0) {
+    free(input_data.data);
+    return -1;
+  }
+
+  if (add_position) {
+    polar_t position = {30.0f, 0.0f, 1.0f};
+    oar_metadata_t *pos_meta =
+        create_object_metadata(&position, 1, TEST_SAMPLES_PER_CHANNEL);
+    if (!pos_meta) {
+      free(input_data.data);
+      return -1;
+    }
+    int ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, pos_meta);
+    free(pos_meta);
+    if (ret != 0) {
+      free(input_data.data);
+      return -1;
+    }
+  }
+
+  *out_channels = oar_get_number_of_output_channels(oar);
+  *out_input_data = input_data.data;
+  return 0;
+}
+
+/* Submit a stimulus block of the given size for one element, filling every
+ * input channel. The renderer copies the block, so the buffer is freed here.
+ * Returns the oar_update_audio_element_data result. */
+static int submit_stimulus_block(oar_t *oar, uint32_t element_id,
+                                 uint32_t samples) {
+  uint32_t channels = oar_get_number_of_audio_element_channels(oar, element_id);
+  if (channels == 0) return -1;
+
+  oar_audio_block_t block;
+  if (alloc_audio_block(channels, samples, &block) != 0) return -1;
+
+  for (uint32_t c = 0; c < channels; ++c) {
+    generate_test_stimulus(block.data + c * samples, samples,
+                           (float)TEST_SAMPLING_RATE);
+  }
+
+  int ret = oar_update_audio_element_data(oar, element_id, &block);
+  free(block.data);
+  return ret;
+}
+
+/* --- Measurement helpers ------------------------------------------------ */
+
 static double sum_abs(const float *data, uint32_t count) {
   double sum = 0.0;
   for (uint32_t i = 0; i < count; ++i) sum += fabs(data[i]);
@@ -273,10 +203,7 @@ static double rms_diff(const float *a, const float *b, uint32_t count) {
   return sqrt(sum / count);
 }
 
-/* --- Setup/teardown helpers for TC1-TC7 to reduce config/output boilerplate.
- * Each TC runs in its own child process (crash isolation), so these helpers
- * do not introduce shared state — they simply eliminate the repeated
- * memset(config) / oar_create / output alloc pattern. --- */
+/* --- Composite setup helpers -------------------------------------------- */
 
 /* Create a binaural OAR instance with a single object element (with default
  * position) and return it along with the output channel count and input data
@@ -284,12 +211,8 @@ static double rms_diff(const float *a, const float *b, uint32_t count) {
 static int create_binaural_oar_with_element(oar_t **out_oar,
                                             uint32_t *out_channels,
                                             float **out_input_data) {
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
   oar_t *oar = oar_create(&config);
   if (!oar) return -1;
 
@@ -306,73 +229,31 @@ static int create_binaural_oar_with_element(oar_t **out_oar,
   return 0;
 }
 
-/* Allocate a zeroed output block matching the given channel count. Returns 0
- * on success. */
-static int alloc_output_block(uint32_t out_channels,
-                              oar_audio_block_t *output) {
-  memset(output, 0, sizeof(*output));
-  output->channels = out_channels;
-  output->samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output->data =
-      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
-  return output->data ? 0 : -1;
-}
-
-/* Render and verify output is non-silent. Returns 0 on success. Cleans up
- * and sets *out_oar to NULL on failure. */
-static int render_and_check_non_silent(oar_t *oar, oar_audio_block_t *output,
-                                       const char *label) {
-  memset(output->data, 0,
-         output->channels * output->samples_per_channel * sizeof(float));
-  int ret = oar_render(oar, output);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d (%s)\n", ret, label);
-    return -1;
-  }
-  uint32_t total = output->channels * output->samples_per_channel;
-  if (!is_output_non_silent(output->data, total)) {
-    fprintf(stderr, "FAIL: output is silent (%s)\n", label);
-    return -1;
-  }
-  return 0;
-}
-
 /* Create a binaural renderer with a single object at the given azimuth,
  * render `frames` full frames (resubmitting stimulus and position before
  * each), and copy the last rendered frame into `out`
  * (2 * TEST_SAMPLES_PER_CHANNEL floats, planar). */
 static int render_binaural_frames(float azimuth, int frames, float *out) {
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
   oar_t *oar = oar_create(&config);
   if (!oar) return -1;
 
   int gid = oar_add_audio_group(oar);
-  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
+  if (gid < 0 ||
+      add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) != 0) {
     oar_destroy(oar);
     return -1;
   }
 
   uint32_t out_channels = oar_get_number_of_output_channels(oar);
   if (out_channels != 2) {
-    fprintf(stderr, "FAIL: expected 2 binaural output channels, got %u.\n",
-            out_channels);
     oar_destroy(oar);
     return -1;
   }
 
   oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
-  if (!output.data) {
+  if (alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -400,942 +281,21 @@ done:
   return ret;
 }
 
-/* TC1: set_metadata(32) after add_group (binaural) — should succeed */
-static int test_set_metadata_after_add_group_binaural() {
-  printf("\n===== TC1: set_metadata(32) after add_group (binaural) =====\n");
-
-  oar_t *oar = NULL;
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (create_binaural_oar_with_element(&oar, &out_channels, &input_data) != 0) {
-    fprintf(stderr, "FAIL: Failed to setup binaural OAR.\n");
-    return -1;
-  }
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret != 0) {
-    fprintf(stderr,
-            "FAIL: set_metadata(32) failed after add_group (binaural). "
-            "Expected success, got %d.\n",
-            ret);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf("PASS: set_metadata(32) succeeded after add_group (binaural).\n");
-  free(input_data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC2: set_metadata(512) after add_group (equal, no-op) — should succeed */
-static int test_set_metadata_equal_after_add_group() {
-  printf(
-      "\n===== TC2: set_metadata(512) after add_group (equal, no-op) =====\n");
-
-  oar_t *oar = NULL;
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (create_binaural_oar_with_element(&oar, &out_channels, &input_data) != 0)
-    return -1;
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SAMPLES_PER_CHANNEL);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: set_metadata(512) returned %d, expected 0.\n", ret);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  if (alloc_output_block(out_channels, &output) != 0) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  int result = 0;
-  if (render_and_check_non_silent(oar, &output, "TC2") != 0) result = -1;
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-
-  if (result == 0)
-    printf("PASS: set_metadata(512) + render succeeded (non-silent).\n");
-  return result;
-}
-
-/* TC3: set_metadata(32) with stereo layout — should succeed */
-static int test_set_metadata_stereo() {
-  printf("\n===== TC3: set_metadata(32) with stereo layout =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_stereo;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: set_metadata(32) on stereo returned %d\n", ret);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-  if (!output.data) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-  memset(output.data, 0,
-         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-
-  ret = oar_render(oar, &output);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render on stereo returned %d\n", ret);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
-  if (!is_output_non_silent(output.data, total_samples)) {
-    fprintf(
-        stderr,
-        "FAIL: output is silent after stereo + set_metadata(32) + render.\n");
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-
-  printf("PASS: stereo + set_metadata(32) + render succeeded (non-silent).\n");
-  return 0;
-}
-
-/* TC4: set_metadata(32) before add_group (binaural) — should succeed */
-static int test_set_metadata_before_add_group_binaural() {
-  printf("\n===== TC4: set_metadata(32) before add_group (binaural) =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: set_metadata(32) before add_group returned %d\n",
-            ret);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-  if (!output.data) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-  memset(output.data, 0,
-         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-
-  ret = oar_render(oar, &output);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
-  if (!is_output_non_silent(output.data, total_samples)) {
-    fprintf(stderr,
-            "FAIL: output is silent after sub-frame rendering. "
-            "OBR may not have processed the 32-sample blocks.\n");
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf(
-      "PASS: set_metadata(32) before add_group + render succeeded "
-      "(output is non-silent).\n");
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC5: default (no set_metadata call, binaural) — backward compatibility */
-static int test_default_no_set_metadata_binaural() {
-  printf("\n===== TC5: default (no set_metadata call, binaural) =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-  if (!output.data) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-  memset(output.data, 0,
-         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-
-  int ret = oar_render(oar, &output);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d (default path)\n", ret);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
-  if (!is_output_non_silent(output.data, total_samples)) {
-    fprintf(stderr, "FAIL: output is silent in default path.\n");
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf("PASS: default (no set_metadata) + render succeeded (non-silent).\n");
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC6: invalid parameters — NULL oar and unsupported metadata type */
-static int test_invalid_parameters() {
-  printf("\n===== TC6: invalid parameters =====\n");
-
-  int ret = oar_set_metadata_unit_to_process(NULL, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret == 0) {
-    fprintf(stderr, "FAIL: set_metadata(NULL) succeeded, expected error.\n");
-    return -1;
-  }
-  printf("  NULL oar: returned %d (expected error) OK\n", ret);
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_gain,
-                                         TEST_SUB_FRAME_SAMPLES);
-  if (ret == 0) {
-    fprintf(
-        stderr,
-        "FAIL: set_metadata(ck_metadata_gain) succeeded, expected error.\n");
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("  unsupported type: returned %d (expected error) OK\n", ret);
-
-  oar_destroy(oar);
-  printf("PASS: invalid parameters correctly rejected.\n");
-  return 0;
-}
-
-/* TC7: multiple set_metadata before add_group — last value wins */
-static int test_multiple_set_metadata_before_add_group() {
-  printf("\n===== TC7: multiple set_metadata before add_group =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: first set_metadata(32) returned %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                         TEST_SUB_FRAME_SAMPLES_ALT);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: second set_metadata(64) returned %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (add_object_element(oar, &out_channels, &input_data, 1) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)malloc(out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-  if (!output.data) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-  memset(output.data, 0,
-         out_channels * TEST_SAMPLES_PER_CHANNEL * sizeof(float));
-
-  ret = oar_render(oar, &output);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t total_samples = out_channels * TEST_SAMPLES_PER_CHANNEL;
-  if (!is_output_non_silent(output.data, total_samples)) {
-    fprintf(stderr, "FAIL: output is silent after multiple set_metadata.\n");
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf(
-      "PASS: multiple set_metadata (last=64) + render succeeded "
-      "(non-silent).\n");
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC8: binaural, non-divisor samples → expect success */
-static int test_binaural_non_divisor_accepted() {
-  printf("\n===== TC8: binaural non-divisor accepted =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret =
-      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
-  oar_destroy(oar);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: non-divisor 100 rejected for binaural (%d).\n", ret);
-    return -1;
-  }
-  printf("PASS: non-divisor 100 accepted for binaural.\n");
-  return 0;
-}
-
-/* TC9: zero samples → expect error */
-static int test_zero_samples_rejected() {
-  printf("\n===== TC9: zero samples rejected =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret =
-      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 0);
-  oar_destroy(oar);
-
-  if (ret == 0) {
-    fprintf(stderr, "FAIL: zero samples accepted.\n");
-    return -1;
-  }
-  printf("PASS: zero samples rejected (%d).\n", ret);
-  return 0;
-}
-
-/* TC10: samples > frame → expect error */
-static int test_exceeds_frame_rejected() {
-  printf("\n===== TC10: samples > frame rejected =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SAMPLES_PER_CHANNEL * 2);
-  oar_destroy(oar);
-
-  if (ret == 0) {
-    fprintf(stderr, "FAIL: samples > frame accepted.\n");
-    return -1;
-  }
-  printf("PASS: samples > frame rejected (%d).\n", ret);
-  return 0;
-}
-
-/* TC11: stereo, non-divisor samples → expect success */
-static int test_stereo_non_divisor_accepted() {
-  printf("\n===== TC11: stereo non-divisor accepted =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_stereo;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret =
-      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
-  oar_destroy(oar);
-
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: non-divisor 100 rejected for stereo (%d).\n", ret);
-    return -1;
-  }
-  printf("PASS: non-divisor 100 accepted for stereo.\n");
-  return 0;
-}
-
-/* TC12: stereo, varying positions across sub-frames → verify position update */
-static int test_stereo_varying_positions_sub_frame() {
-  printf("\n===== TC12: stereo varying positions sub-frame =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_stereo;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
-                                             TEST_SUB_FRAME_SAMPLES);
-  if (ret != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t out_channels = 0;
-  float *input_data = NULL;
-  if (add_object_element(oar, &out_channels, &input_data, 0) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  /* Provide two position metadata entries: first half left, second half right.
-   * In stereo layout: ch0 = +30° (left speaker), ch1 = -30° (right speaker).
-   * Use ±80° so positions are clearly on one side, producing asymmetric gain.
-   * First half: +80° (far left) → ch0 dominant
-   * Second half: -80° (far right) → ch1 dominant */
-  polar_t pos_left = {80.0f, 0.0f, 1.0f};
-  polar_t pos_right = {-80.0f, 0.0f, 1.0f};
-
-  oar_metadata_t *meta_left =
-      create_position_metadata(pos_left, TEST_SAMPLES_PER_CHANNEL / 2);
-  oar_metadata_t *meta_right =
-      create_position_metadata(pos_right, TEST_SAMPLES_PER_CHANNEL / 2);
-
-  if (!meta_left || !meta_right) {
-    fprintf(stderr, "FAIL: create_position_metadata returned NULL.\n");
-    free(meta_left);
-    free(meta_right);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_left);
-  free(meta_left);
-
-  if (ret != 0) {
-    fprintf(stderr,
-            "FAIL: oar_update_audio_element_metadata (left) returned %d.\n",
-            ret);
-    free(meta_right);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_right);
-  free(meta_right);
-  if (ret != 0) {
-    fprintf(stderr,
-            "FAIL: oar_update_audio_element_metadata (right) returned %d.\n",
-            ret);
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
-  if (!output.data) {
-    free(input_data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  ret = oar_render(oar, &output);
-  if (ret != 0) {
-    fprintf(stderr, "FAIL: oar_render returned %d\n", ret);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  /* Verify: left channel first half energy > second half, right channel vice
-   * versa */
-
-  uint32_t half = TEST_SAMPLES_PER_CHANNEL / 2;
-  float left_first_half = 0.0f, left_second_half = 0.0f;
-  float right_first_half = 0.0f, right_second_half = 0.0f;
-
-  for (uint32_t i = 0; i < half; i++) {
-    left_first_half += fabsf(output.data[i]);
-    right_first_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
-  }
-  for (uint32_t i = half; i < TEST_SAMPLES_PER_CHANNEL; i++) {
-    left_second_half += fabsf(output.data[i]);
-    right_second_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
-  }
-
-  if (left_first_half <= left_second_half ||
-      right_second_half <= right_first_half) {
-    fprintf(stderr,
-            "FAIL: sub-frame position update not reflected in output.\n"
-            "  Left ch:  first_half=%.4f, second_half=%.4f\n"
-            "  Right ch: first_half=%.4f, second_half=%.4f\n",
-            left_first_half, left_second_half, right_first_half,
-            right_second_half);
-    free(input_data);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf("PASS: sub-frame position updates reflected in output.\n");
-
-  free(input_data);
-  free(output.data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC13: binaural, mirrored positions (±80°) → outputs differ + ILD flips.
- *
- * Primary assertion: two renders of identical input at mirrored azimuths must
- * differ. If object positions never reach OBR, both render at the creation
- * default (front-center) and the outputs are bit-identical, regardless of the
- * HRIR set. Secondary assertion: the interaural energy asymmetry must follow
- * the azimuth sign (positive azimuth = left, as in TC12). ILD magnitude
- * accuracy is covered by OBR's own unit tests (GetBroadbandILD); only the
- * sign is asserted here. */
-static int test_binaural_position_effect() {
-  printf("\n===== TC13: binaural mirrored positions (±80°) =====\n");
-
-  uint32_t total = 2 * TEST_SAMPLES_PER_CHANNEL;
-  float *render_left = (float *)calloc(total, sizeof(float));
-  float *render_right = (float *)calloc(total, sizeof(float));
-  if (!render_left || !render_right) {
-    free(render_left);
-    free(render_right);
-    return -1;
-  }
-
-  /* Render the second frame so the measurement is past the onset. */
-  if (render_binaural_frames(TEST_SIDE_AZIMUTH, 2, render_left) != 0 ||
-      render_binaural_frames(-TEST_SIDE_AZIMUTH, 2, render_right) != 0) {
-    fprintf(stderr, "FAIL: binaural render failed.\n");
-    free(render_left);
-    free(render_right);
-    return -1;
-  }
-
-  int result = 0;
-  double sig = rms_of(render_left, total);
-  double diff = rms_diff(render_left, render_right, total);
-
-  if (sig < 1e-6) {
-    fprintf(stderr, "FAIL: binaural output is silent (rms=%g).\n", sig);
-    result = -1;
-  } else if (diff < TEST_MIN_RELATIVE_DIFF * sig) {
-    fprintf(stderr,
-            "FAIL: renders at +80° and -80° are (near-)identical "
-            "(diff rms=%g, signal rms=%g). Object positions are not being "
-            "delivered to OBR.\n",
-            diff, sig);
-    result = -1;
-  }
-
-  double e_l_pos = sum_abs(render_left, TEST_SAMPLES_PER_CHANNEL);
-  double e_r_pos =
-      sum_abs(render_left + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
-  double e_l_neg = sum_abs(render_right, TEST_SAMPLES_PER_CHANNEL);
-  double e_r_neg = sum_abs(render_right + TEST_SAMPLES_PER_CHANNEL,
-                           TEST_SAMPLES_PER_CHANNEL);
-
-  if (e_l_pos <= TEST_ILD_RATIO * e_r_pos ||
-      e_r_neg <= TEST_ILD_RATIO * e_l_neg) {
-    fprintf(stderr,
-            "FAIL: interaural asymmetry does not follow azimuth sign.\n"
-            "  +80°: E_L=%.4f, E_R=%.4f (expected E_L dominant)\n"
-            "  -80°: E_L=%.4f, E_R=%.4f (expected E_R dominant)\n",
-            e_l_pos, e_r_pos, e_l_neg, e_r_neg);
-    result = -1;
-  }
-
-  if (result == 0) {
-    printf(
-        "PASS: mirrored positions render differently and ILD follows the "
-        "azimuth sign.\n");
-  }
-
-  free(render_left);
-  free(render_right);
-  return result;
-}
-
-/* TC14: binaural, position update between frames takes effect.
- *
- * OBR's buffer_size_per_channel is fixed at creation, so binaural position
- * updates are frame-granular — but they must still be applied on the next
- * frame. Render at +80°, update to -80°, and assert the interaural balance
- * flips. The frame right after the update is skipped so any position
- * crossfade inside OBR does not blur the measurement. */
-static int test_binaural_position_update_across_frames() {
-  printf("\n===== TC14: binaural position update across frames =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int result = -1;
-  float *frame1 = NULL;
-  float *frame3 = NULL;
-
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.data = NULL;
-
-  int gid = oar_add_audio_group(oar);
-  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
-    fprintf(stderr, "FAIL: element setup failed.\n");
-    goto done;
-  }
-
-  uint32_t out_channels = oar_get_number_of_output_channels(oar);
-  if (out_channels != 2) {
-    fprintf(stderr, "FAIL: expected 2 binaural output channels, got %u.\n",
-            out_channels);
-    goto done;
-  }
-
-  uint32_t total = out_channels * TEST_SAMPLES_PER_CHANNEL;
-  frame1 = (float *)calloc(total, sizeof(float));
-  frame3 = (float *)calloc(total, sizeof(float));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data = (float *)calloc(total, sizeof(float));
-  if (!frame1 || !frame3 || !output.data) goto done;
-
-  /* Frame 1 at +80°, frames 2 and 3 at -80°; measure frames 1 and 3. */
-  float azimuths[3] = {TEST_SIDE_AZIMUTH, -TEST_SIDE_AZIMUTH,
-                       -TEST_SIDE_AZIMUTH};
-  for (int f = 0; f < 3; ++f) {
-    if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
-            0 ||
-        submit_position(oar, TEST_ELEMENT_ID, azimuths[f],
-                        TEST_SAMPLES_PER_CHANNEL) != 0) {
-      fprintf(stderr, "FAIL: data/metadata update failed on frame %d.\n",
-              f + 1);
-      goto done;
-    }
-    memset(output.data, 0, total * sizeof(float));
-    if (oar_render(oar, &output) != 0) {
-      fprintf(stderr, "FAIL: oar_render failed on frame %d.\n", f + 1);
-      goto done;
-    }
-    if (f == 0) memcpy(frame1, output.data, total * sizeof(float));
-    if (f == 2) memcpy(frame3, output.data, total * sizeof(float));
-  }
-
-  double sig = rms_of(frame1, total);
-  double diff = rms_diff(frame1, frame3, total);
-  double e_l_f1 = sum_abs(frame1, TEST_SAMPLES_PER_CHANNEL);
-  double e_r_f1 =
-      sum_abs(frame1 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
-  double e_l_f3 = sum_abs(frame3, TEST_SAMPLES_PER_CHANNEL);
-  double e_r_f3 =
-      sum_abs(frame3 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
-
-  if (sig < 1e-6) {
-    fprintf(stderr, "FAIL: binaural output is silent (rms=%g).\n", sig);
-  } else if (diff < TEST_MIN_RELATIVE_DIFF * sig) {
-    fprintf(stderr,
-            "FAIL: output did not change after the position update "
-            "(diff rms=%g, signal rms=%g).\n",
-            diff, sig);
-  } else if (e_l_f1 <= TEST_ILD_RATIO * e_r_f1 ||
-             e_r_f3 <= TEST_ILD_RATIO * e_l_f3) {
-    fprintf(stderr,
-            "FAIL: interaural balance did not flip after the update.\n"
-            "  frame1 (+80°): E_L=%.4f, E_R=%.4f\n"
-            "  frame3 (-80°): E_L=%.4f, E_R=%.4f\n",
-            e_l_f1, e_r_f1, e_l_f3, e_r_f3);
-  } else {
-    printf("PASS: position update applied on a subsequent frame.\n");
-    result = 0;
-  }
-
-done:
-  free(frame1);
-  free(frame3);
-  free(output.data);
-  oar_destroy(oar);
-  return result;
-}
-
-/* TC15: binaural, input block smaller than the configured frame must be
- * rejected by oar_update_audio_element_data — not fed to OBR, whose
- * ABSL_CHECK_EQ on the buffer size aborts the whole process. */
-static int test_undersized_block_rejected() {
-  printf("\n===== TC15: undersized input block rejected =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int gid = oar_add_audio_group(oar);
-  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  uint32_t out_channels = oar_get_number_of_output_channels(oar);
-  oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
-  if (!output.data) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  int ret =
-      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
-  if (ret == 0) {
-    fprintf(stderr,
-            "FAIL: %u-sample block accepted with samples_per_channel=%u. "
-            "Rendering to demonstrate the failure mode (expect an abort in "
-            "ObrImpl::Process)...\n",
-            TEST_SAMPLES_PER_CHANNEL / 2, TEST_SAMPLES_PER_CHANNEL);
-    fflush(stderr);
-    oar_render(oar, &output);
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("  undersized block: returned %d (expected error) OK\n", ret);
-
-  /* The renderer must remain usable after the rejection. */
-  if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
-          0 ||
-      oar_render(oar, &output) != 0) {
-    fprintf(stderr, "FAIL: renderer unusable after rejected block.\n");
-    free(output.data);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf("PASS: undersized block rejected; renderer still renders.\n");
-  free(output.data);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC16: mismatched block sizes across two elements must be rejected. If both
- * submissions are accepted, add_data memcpys the second element's larger
- * block with the first block's stride/allocation — a heap buffer overflow
- * (deterministic under ASan; here detected via the return codes). */
-static int test_mismatched_blocks_across_elements() {
-  printf("\n===== TC16: mismatched blocks across elements rejected =====\n");
-
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
-  oar_t *oar = oar_create(&config);
-  if (!oar) return -1;
-
-  int gid = oar_add_audio_group(oar);
-  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0 ||
-      add_object_element_to_group(oar, gid, TEST_ELEMENT_ID_2) != 0) {
-    oar_destroy(oar);
-    return -1;
-  }
-
-  int ret_a =
-      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
-  int ret_b =
-      submit_stimulus_block(oar, TEST_ELEMENT_ID_2, TEST_SAMPLES_PER_CHANNEL);
-
-  if (ret_a == 0 && ret_b == 0) {
-    fprintf(stderr,
-            "FAIL: mismatched block sizes (%u then %u) both accepted — the "
-            "second memcpy in add_data overruns the staging buffer sized for "
-            "the first block.\n",
-            TEST_SAMPLES_PER_CHANNEL / 2, TEST_SAMPLES_PER_CHANNEL);
-    oar_destroy(oar);
-    return -1;
-  }
-
-  printf("PASS: mismatched block sizes rejected (first: %d, second: %d).\n",
-         ret_a, ret_b);
-  oar_destroy(oar);
-  return 0;
-}
-
-/* TC17 helper: create a binaural renderer with two object-based elements,
- * where element 1 has num_objects=1 and element 2 has num_objects=2. This
- * simultaneously exercises the multi-element multiplexing path
- * (channel_start_index interleaving, apply_frame_positions per-element) and
- * the multi-object path (polar_positions[1], dual-object metadata_update).
- * Submit data and positions for both, render two frames, and copy the last
- * frame into `out` (2 * TEST_SAMPLES_PER_CHANNEL floats, planar).
- *
- * az1: azimuth for element 1 (single object).
- * az2_obj1, az2_obj2: azimuths for element 2's two objects. */
+/* Create a binaural renderer with two object-based elements, where element 1
+ * has num_objects=1 and element 2 has num_objects=2. Submit data and positions
+ * for both, render two frames, and copy the last frame into `out`
+ * (2 * TEST_SAMPLES_PER_CHANNEL floats, planar). */
 static int render_multi_element_multi_object(float az1, float az2_obj1,
                                              float az2_obj2, float *out) {
-  oar_config_t config;
-  memset(&config, 0, sizeof(config));
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  config.sampling_rate = TEST_SAMPLING_RATE;
-
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
   oar_t *oar = oar_create(&config);
   if (!oar) return -1;
 
   int gid = oar_add_audio_group(oar);
-  if (gid < 0 || add_object_element_to_group(oar, gid, TEST_ELEMENT_ID) != 0 ||
-      add_object_element_to_group_n(oar, gid, TEST_ELEMENT_ID_2, 2) != 0) {
+  if (gid < 0 ||
+      add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) != 0 ||
+      add_object_element_to_group(oar, gid, TEST_ELEMENT_ID_2, 2) != 0) {
     oar_destroy(oar);
     return -1;
   }
@@ -1347,18 +307,12 @@ static int render_multi_element_multi_object(float az1, float az2_obj1,
   }
 
   oar_audio_block_t output;
-  memset(&output, 0, sizeof(output));
-  output.channels = out_channels;
-  output.samples_per_channel = TEST_SAMPLES_PER_CHANNEL;
-  output.data =
-      (float *)calloc(out_channels * TEST_SAMPLES_PER_CHANNEL, sizeof(float));
-  if (!output.data) {
+  if (alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) != 0) {
     oar_destroy(oar);
     return -1;
   }
 
   int ret = -1;
-  /* Submit data and positions for both elements, then render. */
   for (int attempt = 0; attempt < 2; ++attempt) {
     if (submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL) !=
         0)
@@ -1387,6 +341,542 @@ done:
   return ret;
 }
 
+/* --- Test cases --------------------------------------------------------- */
+
+/* TC1: set_metadata(32) after add_group (binaural) — should succeed */
+static int test_set_metadata_after_add_group_binaural(void) {
+  TEST_START("TC1: set_metadata(32) after add_group (binaural)");
+
+  oar_t *oar = NULL;
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(
+      create_binaural_oar_with_element(&oar, &out_channels, &input_data) == 0,
+      "Failed to setup binaural OAR");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret == 0, "set_metadata(32) failed after add_group (binaural)");
+
+  free(input_data);
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* TC2: set_metadata(512) after add_group (equal, no-op) — should succeed */
+static int test_set_metadata_equal_after_add_group(void) {
+  TEST_START("TC2: set_metadata(512) after add_group (equal, no-op)");
+
+  oar_t *oar = NULL;
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(
+      create_binaural_oar_with_element(&oar, &out_channels, &input_data) == 0,
+      "Failed to setup binaural OAR");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SAMPLES_PER_CHANNEL);
+  TEST_ASSERT(ret == 0, "set_metadata(512) returned error");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
+}
+
+/* TC3: set_metadata(32) with stereo layout — should succeed */
+static int test_set_metadata_stereo(void) {
+  TEST_START("TC3: set_metadata(32) with stereo layout");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_stereo, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(add_object_element(oar, &out_channels, &input_data, 1) == 0,
+              "add_object_element failed");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret == 0, "set_metadata(32) on stereo returned error");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
+}
+
+/* TC4: set_metadata(32) before add_group (binaural) — should succeed */
+static int test_set_metadata_before_add_group_binaural(void) {
+  TEST_START("TC4: set_metadata(32) before add_group (binaural)");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret == 0, "set_metadata(32) before add_group returned error");
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(add_object_element(oar, &out_channels, &input_data, 1) == 0,
+              "add_object_element failed");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "output is silent after sub-frame rendering");
+  return TEST_PASS;
+}
+
+/* TC5: default (no set_metadata call, binaural) — backward compatibility */
+static int test_default_no_set_metadata_binaural(void) {
+  TEST_START("TC5: default (no set_metadata call, binaural)");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(add_object_element(oar, &out_channels, &input_data, 1) == 0,
+              "add_object_element failed");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "output is silent in default path");
+  return TEST_PASS;
+}
+
+/* TC6: invalid parameters — NULL oar and unsupported metadata type */
+static int test_invalid_parameters(void) {
+  TEST_START("TC6: invalid parameters");
+
+  int ret = oar_set_metadata_unit_to_process(NULL, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret != 0, "set_metadata(NULL) succeeded, expected error");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_gain,
+                                         TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret != 0,
+              "set_metadata(ck_metadata_gain) succeeded, expected error");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* TC7: multiple set_metadata before add_group — last value wins */
+static int test_multiple_set_metadata_before_add_group(void) {
+  TEST_START("TC7: multiple set_metadata before add_group");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret == 0, "first set_metadata(32) returned error");
+
+  ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                         TEST_SUB_FRAME_SAMPLES_ALT);
+  TEST_ASSERT(ret == 0, "second set_metadata(64) returned error");
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(add_object_element(oar, &out_channels, &input_data, 1) == 0,
+              "add_object_element failed");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "output is silent after multiple set_metadata");
+  return TEST_PASS;
+}
+
+/* TC8: binaural, non-divisor samples → expect success */
+static int test_binaural_non_divisor_accepted(void) {
+  TEST_START("TC8: binaural non-divisor accepted");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
+  oar_destroy(oar);
+
+  TEST_ASSERT(ret == 0, "non-divisor 100 rejected for binaural");
+  return TEST_PASS;
+}
+
+/* TC9: zero samples → expect error */
+static int test_zero_samples_rejected(void) {
+  TEST_START("TC9: zero samples rejected");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 0);
+  oar_destroy(oar);
+
+  TEST_ASSERT(ret != 0, "zero samples accepted");
+  return TEST_PASS;
+}
+
+/* TC10: samples > frame → expect error */
+static int test_exceeds_frame_rejected(void) {
+  TEST_START("TC10: samples > frame rejected");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SAMPLES_PER_CHANNEL * 2);
+  oar_destroy(oar);
+
+  TEST_ASSERT(ret != 0, "samples > frame accepted");
+  return TEST_PASS;
+}
+
+/* TC11: stereo, non-divisor samples → expect success */
+static int test_stereo_non_divisor_accepted(void) {
+  TEST_START("TC11: stereo non-divisor accepted");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_stereo, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret =
+      oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions, 100);
+  oar_destroy(oar);
+
+  TEST_ASSERT(ret == 0, "non-divisor 100 rejected for stereo");
+  return TEST_PASS;
+}
+
+/* TC12: stereo, varying positions across sub-frames → verify position update */
+static int test_stereo_varying_positions_sub_frame(void) {
+  TEST_START("TC12: stereo varying positions sub-frame");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_stereo, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int ret = oar_set_metadata_unit_to_process(oar, ck_metadata_object_positions,
+                                             TEST_SUB_FRAME_SAMPLES);
+  TEST_ASSERT(ret == 0, "set_metadata(32) failed");
+
+  uint32_t out_channels = 0;
+  float *input_data = NULL;
+  TEST_ASSERT(add_object_element(oar, &out_channels, &input_data, 0) == 0,
+              "add_object_element failed");
+
+  /* Provide two position metadata entries: first half left, second half right.
+   * First half: +80° (far left) → ch0 dominant
+   * Second half: -80° (far right) → ch1 dominant */
+  polar_t pos_left = {80.0f, 0.0f, 1.0f};
+  polar_t pos_right = {-80.0f, 0.0f, 1.0f};
+  oar_metadata_t *meta_left =
+      create_object_metadata(&pos_left, 1, TEST_SAMPLES_PER_CHANNEL / 2);
+  oar_metadata_t *meta_right =
+      create_object_metadata(&pos_right, 1, TEST_SAMPLES_PER_CHANNEL / 2);
+  TEST_ASSERT(meta_left != NULL && meta_right != NULL,
+              "create_object_metadata returned NULL");
+
+  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_left);
+  free(meta_left);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_metadata (left) failed");
+
+  ret = oar_update_audio_element_metadata(oar, TEST_ELEMENT_ID, meta_right);
+  free(meta_right);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_metadata (right) failed");
+
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  ret = oar_render(oar, &output);
+  TEST_ASSERT(ret == 0, "oar_render returned error");
+
+  /* Verify: left channel first half energy > second half, right channel vice
+   * versa */
+  uint32_t half = TEST_SAMPLES_PER_CHANNEL / 2;
+  float left_first_half = 0.0f, left_second_half = 0.0f;
+  float right_first_half = 0.0f, right_second_half = 0.0f;
+
+  for (uint32_t i = 0; i < half; i++) {
+    left_first_half += fabsf(output.data[i]);
+    right_first_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
+  }
+  for (uint32_t i = half; i < TEST_SAMPLES_PER_CHANNEL; i++) {
+    left_second_half += fabsf(output.data[i]);
+    right_second_half += fabsf(output.data[TEST_SAMPLES_PER_CHANNEL + i]);
+  }
+
+  TEST_ASSERT(left_first_half > left_second_half,
+              "sub-frame position update not reflected in left channel");
+  TEST_ASSERT(right_second_half > right_first_half,
+              "sub-frame position update not reflected in right channel");
+
+  free(input_data);
+  free(output.data);
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* TC13: binaural, mirrored positions (±80°) → outputs differ + ILD flips.
+ *
+ * Primary assertion: two renders of identical input at mirrored azimuths must
+ * differ. If object positions never reach OBR, both render at the creation
+ * default (front-center) and the outputs are bit-identical, regardless of the
+ * HRIR set. Secondary assertion: the interaural energy asymmetry must follow
+ * the azimuth sign (positive azimuth = left, as in TC12). */
+static int test_binaural_position_effect(void) {
+  TEST_START("TC13: binaural mirrored positions (±80°)");
+
+  uint32_t total = 2 * TEST_SAMPLES_PER_CHANNEL;
+  float *render_left = (float *)calloc(total, sizeof(float));
+  float *render_right = (float *)calloc(total, sizeof(float));
+  TEST_ASSERT(render_left != NULL && render_right != NULL, "calloc failed");
+
+  /* Render the second frame so the measurement is past the onset. */
+  TEST_ASSERT(render_binaural_frames(TEST_SIDE_AZIMUTH, 2, render_left) == 0,
+              "binaural render (+azimuth) failed");
+  TEST_ASSERT(render_binaural_frames(-TEST_SIDE_AZIMUTH, 2, render_right) == 0,
+              "binaural render (-azimuth) failed");
+
+  double sig = rms_of(render_left, total);
+  double diff = rms_diff(render_left, render_right, total);
+
+  TEST_ASSERT(sig >= 1e-6, "binaural output is silent");
+  TEST_ASSERT(diff >= TEST_MIN_RELATIVE_DIFF * sig,
+              "renders at +80° and -80° are near-identical; positions not "
+              "delivered to OBR");
+
+  double e_l_pos = sum_abs(render_left, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_pos =
+      sum_abs(render_left + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+  double e_l_neg = sum_abs(render_right, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_neg = sum_abs(render_right + TEST_SAMPLES_PER_CHANNEL,
+                           TEST_SAMPLES_PER_CHANNEL);
+
+  TEST_ASSERT(e_l_pos > TEST_ILD_RATIO * e_r_pos,
+              "interaural asymmetry does not follow azimuth sign (+80°)");
+  TEST_ASSERT(e_r_neg > TEST_ILD_RATIO * e_l_neg,
+              "interaural asymmetry does not follow azimuth sign (-80°)");
+
+  free(render_left);
+  free(render_right);
+  return TEST_PASS;
+}
+
+/* TC14: binaural, position update between frames takes effect.
+ *
+ * OBR's buffer_size_per_channel is fixed at creation, so binaural position
+ * updates are frame-granular — but they must still be applied on the next
+ * frame. Render at +80°, update to -80°, and assert the interaural balance
+ * flips. The frame right after the update is skipped so any position
+ * crossfade inside OBR does not blur the measurement. */
+static int test_binaural_position_update_across_frames(void) {
+  TEST_START("TC14: binaural position update across frames");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+  TEST_ASSERT(add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) == 0,
+              "add_object_element_to_group failed");
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  TEST_ASSERT_EQ(out_channels, (uint32_t)2,
+                 "expected 2 binaural output channels");
+
+  uint32_t total = out_channels * TEST_SAMPLES_PER_CHANNEL;
+  float *frame1 = (float *)calloc(total, sizeof(float));
+  float *frame3 = (float *)calloc(total, sizeof(float));
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+  TEST_ASSERT(frame1 != NULL && frame3 != NULL, "calloc failed");
+
+  /* Frame 1 at +80°, frames 2 and 3 at -80°; measure frames 1 and 3. */
+  float azimuths[3] = {TEST_SIDE_AZIMUTH, -TEST_SIDE_AZIMUTH,
+                       -TEST_SIDE_AZIMUTH};
+  for (int f = 0; f < 3; ++f) {
+    TEST_ASSERT(submit_stimulus_block(oar, TEST_ELEMENT_ID,
+                                      TEST_SAMPLES_PER_CHANNEL) == 0,
+                "data update failed");
+    TEST_ASSERT(submit_position(oar, TEST_ELEMENT_ID, azimuths[f],
+                                TEST_SAMPLES_PER_CHANNEL) == 0,
+                "metadata update failed");
+    memset(output.data, 0, total * sizeof(float));
+    TEST_ASSERT(oar_render(oar, &output) == 0, "oar_render failed");
+    if (f == 0) memcpy(frame1, output.data, total * sizeof(float));
+    if (f == 2) memcpy(frame3, output.data, total * sizeof(float));
+  }
+
+  double sig = rms_of(frame1, total);
+  double diff = rms_diff(frame1, frame3, total);
+  double e_l_f1 = sum_abs(frame1, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_f1 =
+      sum_abs(frame1 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+  double e_l_f3 = sum_abs(frame3, TEST_SAMPLES_PER_CHANNEL);
+  double e_r_f3 =
+      sum_abs(frame3 + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
+
+  TEST_ASSERT(sig >= 1e-6, "binaural output is silent");
+  TEST_ASSERT(diff >= TEST_MIN_RELATIVE_DIFF * sig,
+              "output did not change after the position update");
+  TEST_ASSERT(
+      e_l_f1 > TEST_ILD_RATIO * e_r_f1,
+      "interaural balance did not flip: frame1 (+80°) E_L not dominant");
+  TEST_ASSERT(
+      e_r_f3 > TEST_ILD_RATIO * e_l_f3,
+      "interaural balance did not flip: frame3 (-80°) E_R not dominant");
+
+  free(frame1);
+  free(frame3);
+  free(output.data);
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* TC15: binaural, input block smaller than the configured frame must be
+ * rejected by oar_update_audio_element_data — not fed to OBR, whose
+ * ABSL_CHECK_EQ on the buffer size aborts the whole process. */
+static int test_undersized_block_rejected(void) {
+  TEST_START("TC15: undersized input block rejected");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+  TEST_ASSERT(add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) == 0,
+              "add_object_element_to_group failed");
+
+  uint32_t out_channels = oar_get_number_of_output_channels(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(out_channels, TEST_SAMPLES_PER_CHANNEL, &output) == 0,
+      "alloc_audio_block failed");
+
+  int ret =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
+  TEST_ASSERT(ret != 0, "undersized block was accepted");
+
+  /* The renderer must remain usable after the rejection. */
+  TEST_ASSERT(submit_stimulus_block(oar, TEST_ELEMENT_ID,
+                                    TEST_SAMPLES_PER_CHANNEL) == 0,
+              "full-size block rejected after undersized rejection");
+  TEST_ASSERT(oar_render(oar, &output) == 0,
+              "renderer unusable after rejected block");
+
+  free(output.data);
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+/* TC16: mismatched block sizes across two elements must be rejected. If both
+ * submissions are accepted, add_data memcpys the second element's larger
+ * block with the first block's stride/allocation — a heap buffer overflow. */
+static int test_mismatched_blocks_across_elements(void) {
+  TEST_START("TC16: mismatched blocks across elements rejected");
+
+  oar_config_t config =
+      create_config(ck_oar_layout_binaural, TEST_SAMPLES_PER_CHANNEL, 48000);
+  oar_t *oar = oar_create(&config);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+  TEST_ASSERT(add_object_element_to_group(oar, gid, TEST_ELEMENT_ID, 1) == 0,
+              "add element 1 failed");
+  TEST_ASSERT(add_object_element_to_group(oar, gid, TEST_ELEMENT_ID_2, 1) == 0,
+              "add element 2 failed");
+
+  int ret_a =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID, TEST_SAMPLES_PER_CHANNEL / 2);
+  int ret_b =
+      submit_stimulus_block(oar, TEST_ELEMENT_ID_2, TEST_SAMPLES_PER_CHANNEL);
+
+  TEST_ASSERT(
+      !(ret_a == 0 && ret_b == 0),
+      "mismatched block sizes both accepted — heap buffer overflow risk");
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
 /* TC17: binaural, multi-element + multi-object rendering.
  *
  * audio_elements_renderer (plural) multiplexes multiple object-based elements
@@ -1405,58 +895,37 @@ done:
  *      objects within the num_objects=2 element reach OBR independently.
  *   3. The two renders differ, proving the multi-object positions affect
  *      output. */
-static int test_multi_element_rendering() {
-  printf("\n===== TC17: multi-element + multi-object rendering =====\n");
+static int test_multi_element_rendering(void) {
+  TEST_START("TC17: multi-element + multi-object rendering");
 
   uint32_t total = 2 * TEST_SAMPLES_PER_CHANNEL;
   float *render_opposite = (float *)calloc(total, sizeof(float));
   float *render_same = (float *)calloc(total, sizeof(float));
-  if (!render_opposite || !render_same) {
-    free(render_opposite);
-    free(render_same);
-    return -1;
-  }
+  TEST_ASSERT(render_opposite != NULL && render_same != NULL, "calloc failed");
 
   /* Render with split objects: element 1 at +80°, element 2's two objects
    * at +80° and -80°. Element 2's objects span both sides, weakening ILD. */
-  if (render_multi_element_multi_object(TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH,
-                                        -TEST_SIDE_AZIMUTH,
-                                        render_opposite) != 0) {
-    fprintf(stderr, "FAIL: multi-element render (split) failed.\n");
-    free(render_opposite);
-    free(render_same);
-    return -1;
-  }
+  TEST_ASSERT(render_multi_element_multi_object(
+                  TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH, -TEST_SIDE_AZIMUTH,
+                  render_opposite) == 0,
+              "multi-element render (split) failed");
 
   /* Render with all objects on same side: element 1 at +80°, element 2's
    * two objects both at +80°. All three objects on the left → strong ILD. */
-  if (render_multi_element_multi_object(TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH,
-                                        TEST_SIDE_AZIMUTH, render_same) != 0) {
-    fprintf(stderr, "FAIL: multi-element render (same) failed.\n");
-    free(render_opposite);
-    free(render_same);
-    return -1;
-  }
-
-  int result = 0;
+  TEST_ASSERT(
+      render_multi_element_multi_object(TEST_SIDE_AZIMUTH, TEST_SIDE_AZIMUTH,
+                                        TEST_SIDE_AZIMUTH, render_same) == 0,
+      "multi-element render (same) failed");
 
   /* 1. Both renders must be non-silent. */
   double sig_opposite = rms_of(render_opposite, total);
   double sig_same = rms_of(render_same, total);
-  if (sig_opposite < 1e-6) {
-    fprintf(stderr, "FAIL: opposite-azimuth output is silent (rms=%g).\n",
-            sig_opposite);
-    result = -1;
-  } else if (sig_same < 1e-6) {
-    fprintf(stderr, "FAIL: same-azimuth output is silent (rms=%g).\n",
-            sig_same);
-    result = -1;
-  }
+  TEST_ASSERT(sig_opposite >= 1e-6, "opposite-azimuth output is silent");
+  TEST_ASSERT(sig_same >= 1e-6, "same-azimuth output is silent");
 
   /* 2. When both elements are at +80°, the left ear should be strongly
    *    dominant (both objects on the left). When they are at opposite
-   *    azimuths, the ILD should be weaker (one object each side).
-   *    Verify: |E_L - E_R| / (E_L + E_R) is larger for same-azimuth. */
+   *    azimuths, the ILD should be weaker (one object each side). */
   double e_l_same = sum_abs(render_same, TEST_SAMPLES_PER_CHANNEL);
   double e_r_same =
       sum_abs(render_same + TEST_SAMPLES_PER_CHANNEL, TEST_SAMPLES_PER_CHANNEL);
@@ -1467,221 +936,53 @@ static int test_multi_element_rendering() {
   double ild_same = fabs(e_l_same - e_r_same) / (e_l_same + e_r_same + 1e-12);
   double ild_opp = fabs(e_l_opp - e_r_opp) / (e_l_opp + e_r_opp + 1e-12);
 
-  if (ild_same <= ild_opp) {
-    fprintf(stderr,
-            "FAIL: ILD not stronger when both elements share azimuth.\n"
-            "  same azimuth (+80,+80): ILD=%.4f (E_L=%.4f, E_R=%.4f)\n"
-            "  opposite (+80,-80):     ILD=%.4f (E_L=%.4f, E_R=%.4f)\n"
-            "  Expected same-azimuth ILD > opposite-azimuth ILD, confirming\n"
-            "  both elements' positions reach OBR independently.\n",
-            ild_same, e_l_same, e_r_same, ild_opp, e_l_opp, e_r_opp);
-    result = -1;
-  }
+  TEST_ASSERT(ild_same > ild_opp,
+              "ILD not stronger when both elements share azimuth");
 
   /* 3. The two renders must differ (proves element 2's data affects output). */
   double diff = rms_diff(render_opposite, render_same, total);
-  if (diff < TEST_MIN_RELATIVE_DIFF * sig_same) {
-    fprintf(stderr,
-            "FAIL: opposite-azimuth and same-azimuth renders are "
-            "near-identical (diff rms=%g, signal rms=%g). Element 2's data "
-            "or position may not be reaching OBR.\n",
-            diff, sig_same);
-    result = -1;
-  }
-
-  if (result == 0) {
-    printf(
-        "PASS: two elements rendered simultaneously with independent "
-        "positions.\n");
-  }
+  TEST_ASSERT(diff >= TEST_MIN_RELATIVE_DIFF * sig_same,
+              "opposite and same-azimuth renders are near-identical");
 
   free(render_opposite);
   free(render_same);
-  return result;
+  return TEST_PASS;
 }
 
-/* Unified test table for child-process dispatch. Each entry combines the
- * short name, human-readable description, and test function in one place,
- * eliminating the need to keep separate arrays in sync. */
-typedef int (*test_fn_t)(void);
-typedef struct {
-  const char *name;
-  const char *description;
-  test_fn_t fn;
-} test_entry_t;
+/* --- Test table --------------------------------------------------------- */
 
 static test_entry_t g_tests[] = {
-    {"TC1", "set_metadata after add_group",
-     test_set_metadata_after_add_group_binaural},
-    {"TC2", "set_metadata equal, no-op",
-     test_set_metadata_equal_after_add_group},
-    {"TC3", "stereo + set_metadata", test_set_metadata_stereo},
-    {"TC4", "set_metadata before add_group",
-     test_set_metadata_before_add_group_binaural},
-    {"TC5", "default, no set_metadata", test_default_no_set_metadata_binaural},
-    {"TC6", "invalid parameters", test_invalid_parameters},
-    {"TC7", "multiple set_metadata",
-     test_multiple_set_metadata_before_add_group},
-    {"TC8", "binaural non-divisor", test_binaural_non_divisor_accepted},
-    {"TC9", "zero samples", test_zero_samples_rejected},
-    {"TC10", "samples > frame", test_exceeds_frame_rejected},
-    {"TC11", "stereo non-divisor", test_stereo_non_divisor_accepted},
-    {"TC12", "stereo varying positions",
-     test_stereo_varying_positions_sub_frame},
-    {"TC13", "binaural mirrored positions", test_binaural_position_effect},
-    {"TC14", "binaural update across frames",
-     test_binaural_position_update_across_frames},
-    {"TC15", "undersized block rejected", test_undersized_block_rejected},
-    {"TC16", "mismatched blocks rejected",
-     test_mismatched_blocks_across_elements},
-    {"TC17", "multi-element + multi-object rendering",
-     test_multi_element_rendering},
+    TEST_ENTRY("TC1", "set_metadata after add_group",
+               test_set_metadata_after_add_group_binaural),
+    TEST_ENTRY("TC2", "set_metadata equal, no-op",
+               test_set_metadata_equal_after_add_group),
+    TEST_ENTRY("TC3", "stereo + set_metadata", test_set_metadata_stereo),
+    TEST_ENTRY("TC4", "set_metadata before add_group",
+               test_set_metadata_before_add_group_binaural),
+    TEST_ENTRY("TC5", "default, no set_metadata",
+               test_default_no_set_metadata_binaural),
+    TEST_ENTRY("TC6", "invalid parameters", test_invalid_parameters),
+    TEST_ENTRY("TC7", "multiple set_metadata",
+               test_multiple_set_metadata_before_add_group),
+    TEST_ENTRY("TC8", "binaural non-divisor",
+               test_binaural_non_divisor_accepted),
+    TEST_ENTRY("TC9", "zero samples", test_zero_samples_rejected),
+    TEST_ENTRY("TC10", "samples > frame", test_exceeds_frame_rejected),
+    TEST_ENTRY("TC11", "stereo non-divisor", test_stereo_non_divisor_accepted),
+    TEST_ENTRY("TC12", "stereo varying positions",
+               test_stereo_varying_positions_sub_frame),
+    TEST_ENTRY("TC13", "binaural mirrored positions",
+               test_binaural_position_effect),
+    TEST_ENTRY("TC14", "binaural update across frames",
+               test_binaural_position_update_across_frames),
+    TEST_ENTRY("TC15", "undersized block rejected",
+               test_undersized_block_rejected),
+    TEST_ENTRY("TC16", "mismatched blocks rejected",
+               test_mismatched_blocks_across_elements),
+    TEST_ENTRY("TC17", "multi-element + multi-object rendering",
+               test_multi_element_rendering),
 };
 
-#define NUM_TESTS (int)(sizeof(g_tests) / sizeof(g_tests[0]))
-
-/* Run a test function in a separate child process so that a crash
- * does not prevent subsequent tests from running.
- *
- * On Linux/macOS, fork() + waitpid() is used.
- * On Windows (MSVC), _spawnl(_P_WAIT, ...) re-invokes this executable
- * with "--child <index>" to run a single test in a child process.
- * Both paths provide identical crash isolation behaviour. */
-static int run_test_in_child(int test_index) {
-  const char *name = g_tests[test_index].name;
-
-#ifndef _WIN32
-  test_fn_t test_fn = g_tests[test_index].fn;
-
-  fflush(stdout);
-  fflush(stderr);
-
-  pid_t pid = fork();
-  if (pid < 0) {
-    perror("fork");
-    return -1;
-  }
-
-  if (pid == 0) {
-    int ret = test_fn();
-    fflush(stdout);
-    fflush(stderr);
-    _exit(ret);
-  }
-
-  int status = 0;
-  waitpid(pid, &status, 0);
-
-  if (WIFEXITED(status)) {
-    int exit_code = WEXITSTATUS(status);
-    if (exit_code == 0) {
-      printf("[%s] PASSED (exit 0)\n", name);
-      return 0;
-    } else {
-      printf("[%s] FAILED (exit %d)\n", name, exit_code);
-      return -1;
-    }
-  } else if (WIFSIGNALED(status)) {
-    int sig = WTERMSIG(status);
-    printf("[%s] CRASHED (signal %d: %s)\n", name, sig,
-           sig == SIGABRT ? "SIGABRT" : "other");
-    return -1;
-  }
-
-  printf("[%s] UNKNOWN failure\n", name);
-  return -1;
-#else
-  /* Windows: spawn a child process that runs a single test. */
-  char index_str[16];
-  char exe_path[1024];
-  DWORD len = GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
-  if (len == 0 || len >= sizeof(exe_path)) {
-    fprintf(stderr, "[%s] FAILED: cannot get executable path\n", name);
-    return -1;
-  }
-
-  snprintf(index_str, sizeof(index_str), "%d", test_index);
-
-  /* Quote the exe path for argv[0] to handle paths containing spaces.
-   * _spawnl's cmdname (first exe_path) is used to locate the executable
-   * and is not parsed as a command line, so it doesn't need quoting.
-   * argv[0] (second exe_path) is written into the command line string and
-   * needs quoting for non-MSVC CRTs that don't auto-quote argv[0]. */
-  char quoted_path[1028];
-  snprintf(quoted_path, sizeof(quoted_path), "\"%s\"", exe_path);
-
-  errno = 0;
-  int exit_code =
-      _spawnl(_P_WAIT, exe_path, quoted_path, "--child", index_str, NULL);
-
-  if (exit_code == -1) {
-    /* The child process never exits with -1 (see main(): failures are mapped
-     * to exit code 1), so -1 unambiguously means _spawnl itself failed to
-     * launch the child.  errno provides additional diagnostic detail. */
-    fprintf(stderr, "[%s] FAILED: spawn error (errno %d: %s)\n", name, errno,
-            strerror(errno));
-    return -1;
-  } else if (exit_code == 0) {
-    printf("[%s] PASSED (exit 0)\n", name);
-    return 0;
-  } else {
-    /* Non-zero exit: test failure or crash.
-     * On Windows, a crash typically yields exit code 3
-     * (STATUS_ACCESS_VIOLATION) or similar non-zero codes. */
-    printf("[%s] FAILED/CRASHED (exit %d)\n", name, exit_code);
-    return -1;
-  }
-
-#endif
-}
-
 int main(int argc, char *argv[]) {
-  /* Child-process mode: run a single test by index and return its result.
-   * Used by _spawnl on Windows to achieve crash isolation. */
-  if (argc >= 3 && strcmp(argv[1], "--child") == 0) {
-    int index = atoi(argv[2]);
-    if (index < 0 || index >= NUM_TESTS) {
-      return 2; /* sentinel: invalid index (distinct from test failure) */
-    }
-    int ret = g_tests[index].fn();
-
-    fflush(stdout);
-    fflush(stderr);
-    /* Map -1 (test failure) to exit code 1 so that -1 from _spawnl uniquely
-     * identifies a spawn failure rather than colliding with the child's own
-     * failure return. */
-    return (ret != 0) ? 1 : 0;
-  }
-
-  printf("========================================\n");
-  printf("Metadata Unit Processing Tests\n");
-  printf("  samples_per_channel: %d\n", TEST_SAMPLES_PER_CHANNEL);
-  printf("  sub_frame_samples:   %d\n", TEST_SUB_FRAME_SAMPLES);
-  printf("  sampling_rate:       %d\n", TEST_SAMPLING_RATE);
-  printf("========================================\n");
-
-  int result = 0;
-  int tc_results[NUM_TESTS];
-
-  for (int i = 0; i < NUM_TESTS; i++) {
-    printf("\n--- Running %s ---\n", g_tests[i].name);
-    tc_results[i] = run_test_in_child(i);
-    result |= (tc_results[i] != 0) ? 1 : 0;
-  }
-
-  printf("\n========================================\n");
-  printf("Test Summary:\n");
-  for (int i = 0; i < NUM_TESTS; i++) {
-    printf("  %s (%s): %s\n", g_tests[i].name, g_tests[i].description,
-           tc_results[i] == 0 ? "PASSED" : "FAILED/CRASHED");
-  }
-  printf("========================================\n");
-
-  if (result == 0) {
-    printf("\nAll tests passed.\n");
-  } else {
-    printf("\nSome tests failed or crashed. Review output above.\n");
-  }
-
-  return result;
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }

--- a/tests/examples/test_object_based_rendering.c
+++ b/tests/examples/test_object_based_rendering.c
@@ -10,86 +10,50 @@
  * www.aomedia.org/license/patent.
  */
 
-#include <math.h>  // For sine wave generation
+/**
+ * @file test_object_based_rendering.c
+ * @brief Test object-based audio element rendering with various configurations.
+ *
+ * Test matrix:
+ *   TC1: Single object at 30° azimuth, 440 Hz — render and verify non-silent.
+ *   TC2: Two objects in one element (dual-mono) at ±45° — render and verify.
+ *   TC3: Two single-object elements in separate groups — render and verify.
+ *   TC4: Animated object positions (−45° → +45°) — render and verify.
+ *   TC5: Object with gain metadata (−6 dB) — render and verify.
+ *   TC6: Invalid parameters (NULL metadata, non-existent element) — expect
+ *        errors.
+ */
+
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-// Include the OAR header
 #include "animation.h"
 #include "oar.h"
 #include "oar_base.h"
 #include "oar_metadata.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
-// Helper function to create a basic OAR config
-oar_config_t create_default_oar_config() {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_stereo;  // Render to stereo
-  config.samples_per_channel = 256;             // Smaller block for testing
-  config.sampling_rate = 48000;
-  return config;
-}
+/* --- Local helpers ------------------------------------------------------ */
 
-// Helper function to generate a simple sine wave for a given channel
-void generate_sine_wave(float* buffer, uint32_t samples, float frequency,
-                        float sample_rate) {
-  for (uint32_t i = 0; i < samples; ++i) {
-    buffer[i] = (float)sin(2.0 * M_PI * frequency * ((float)i / sample_rate));
-  }
-}
-
-// Helper function to create object metadata for multiple objects
-oar_metadata_t* create_object_metadata(const polar_t* positions,
-                                       uint32_t num_objects,
-                                       uint32_t samples_per_channel) {
-  if (num_objects == 0 || num_objects > def_max_number_of_objects ||
-      !positions) {
-    return NULL;
-  }
-
-  oar_metadata_t* metadata = (oar_metadata_t*)malloc(sizeof(oar_metadata_t));
-  if (!metadata) return NULL;
-
-  metadata->type = ck_metadata_object_positions;
-  metadata->duration = (int)samples_per_channel;  // Valid for the current frame
-
-  metadata->object_positions.param_type = ck_param_constant;
-  metadata->object_positions.position_type = ck_polar;
-  metadata->object_positions.num_objects = num_objects;
-
-  for (uint32_t i = 0; i < num_objects; ++i) {
-    metadata->object_positions.polar_positions[i].azimuth =
-        positions[i].azimuth;
-    metadata->object_positions.polar_positions[i].elevation =
-        positions[i].elevation;
-    metadata->object_positions.polar_positions[i].distance =
-        positions[i].distance;
-  }
-
-  return metadata;
-}
-
-// Helper function to create animated object metadata
-oar_metadata_t* create_animated_object_metadata(const polar_t* start_positions,
-                                                const polar_t* end_positions,
-                                                uint32_t num_objects,
-                                                uint32_t samples_per_channel) {
+/* Create animated object metadata (heap-allocated, caller must free). */
+static oar_metadata_t *create_animated_object_metadata(
+    const polar_t *start_positions, const polar_t *end_positions,
+    uint32_t num_objects, uint32_t samples_per_channel) {
   if (num_objects == 0 || num_objects > def_max_number_of_objects ||
       !start_positions || !end_positions) {
     return NULL;
   }
 
-  oar_metadata_t* metadata = (oar_metadata_t*)malloc(sizeof(oar_metadata_t));
+  oar_metadata_t *metadata = (oar_metadata_t *)malloc(sizeof(oar_metadata_t));
   if (!metadata) return NULL;
 
+  memset(metadata, 0, sizeof(*metadata));
   metadata->type = ck_metadata_object_positions;
   metadata->duration = (int)samples_per_channel;
-
   metadata->object_positions.param_type = ck_param_animated;
   metadata->object_positions.position_type = ck_polar;
   metadata->object_positions.num_objects = num_objects;
@@ -114,13 +78,15 @@ oar_metadata_t* create_animated_object_metadata(const polar_t* start_positions,
   return metadata;
 }
 
-// Helper function to create gain metadata
-// Note: gain_value should be specified in decibels (dB)
-oar_metadata_t* create_gain_metadata(uint32_t gain_id, float gain_value_db,
-                                     uint32_t samples_per_channel) {
-  oar_metadata_t* metadata = (oar_metadata_t*)malloc(sizeof(oar_metadata_t));
+/* Create gain metadata (heap-allocated, caller must free).
+ * gain_value should be specified in decibels (dB). */
+static oar_metadata_t *create_gain_metadata(uint32_t gain_id,
+                                            float gain_value_db,
+                                            uint32_t samples_per_channel) {
+  oar_metadata_t *metadata = (oar_metadata_t *)malloc(sizeof(oar_metadata_t));
   if (!metadata) return NULL;
 
+  memset(metadata, 0, sizeof(*metadata));
   metadata->type = ck_metadata_gain;
   metadata->duration = (int)samples_per_channel;
   metadata->gain.id = gain_id;
@@ -130,620 +96,280 @@ oar_metadata_t* create_gain_metadata(uint32_t gain_id, float gain_value_db,
   return metadata;
 }
 
-// Internal helper to add a single or dual object audio element, configure data
-// and metadata. Returns 0 on success, -1 on failure.
-static int _add_object_element(oar_t* oar, uint32_t element_id, int num_objects,
-                               const char* element_description_tag,
-                               uint32_t num_objects_to_configure,
-                               const polar_t* positions,
-                               const float* frequencies) {
-  printf("\n--- Adding %s (ID: %d, num_objects: %d) ---\n",
-         element_description_tag, element_id, num_objects);
+/* Add an object element, feed sine data, and attach position metadata.
+ * Returns 0 on success, -1 on failure. */
+static int add_object_element_with_data(oar_t *oar, uint32_t element_id,
+                                        int num_objects,
+                                        const polar_t *positions,
+                                        const float *frequencies) {
+  int gid = oar_add_audio_group(oar);
+  if (gid < 0) return -1;
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Failed to add audio group for %s. Error code: %d\n",
-            element_description_tag, group_id);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added for %s.\n", group_id,
-         element_description_tag);
-
-  oar_audio_element_config_t element_cfg;
-  element_cfg.type = ck_object_based;
-  element_cfg.obc.num_objects = num_objects;
-  memset(&element_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  int ret = oar_add_audio_element(oar, group_id, element_id, &element_cfg);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to add %s audio element. Error code: %d\n",
-            element_description_tag, ret);
-    return -1;
-  }
-  printf("%s audio element (ID: %d) added successfully to group %d.\n",
-         element_description_tag, element_id, group_id);
+  oar_audio_element_config_t element_cfg =
+      create_object_element_config(num_objects);
+  int ret = oar_add_audio_element(oar, gid, element_id, &element_cfg);
+  if (ret != 0) return -1;
 
   uint32_t input_channels =
       oar_get_number_of_audio_element_channels(oar, element_id);
   uint32_t samples_per_channel = oar_get_samples_per_channel(oar);
 
-  printf("Input channels for %s: %u, Samples per channel: %u\n",
-         element_description_tag, input_channels, samples_per_channel);
-
-  if (num_objects == 1) {
-    if (input_channels != 1) {
-      fprintf(stderr,
-              "Error: Expected 1 input channel for 1 object, but got %u\n",
-              input_channels);
-      oar_remove_audio_element(oar, element_id);
-      return -1;
-    }
-  } else if (num_objects == 2) {
-    if (input_channels != 2) {
-      fprintf(stderr,
-              "Error: Expected 2 input channels for 2 objects, but got %u\n",
-              input_channels);
-      oar_remove_audio_element(oar, element_id);
-      return -1;
-    }
-  } else {
-    fprintf(stderr, "Error: Unsupported number of objects: %d\n", num_objects);
-    oar_remove_audio_element(oar, element_id);
-    return -1;
-  }
-
-  if (input_channels == 0 || num_objects_to_configure > input_channels) {
-    fprintf(stderr, "Channel/object mismatch for %s. Aborting.\n",
-            element_description_tag);
-    oar_remove_audio_element(oar, element_id);
-    return -1;
-  }
-
   oar_audio_block_t input_data;
-  input_data.channels = input_channels;
-  input_data.samples_per_channel = samples_per_channel;
-  input_data.data =
-      (float*)malloc(input_channels * samples_per_channel * sizeof(float));
-  if (input_data.data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for %s input data.\n",
-            element_description_tag);
-    oar_remove_audio_element(oar, element_id);
+  if (alloc_audio_block(input_channels, samples_per_channel, &input_data) != 0)
     return -1;
-  }
 
-  for (uint32_t i = 0; i < num_objects_to_configure; ++i) {
-    generate_sine_wave(input_data.data + i * samples_per_channel,
-                       samples_per_channel, frequencies[i], 48000.0);
-    printf("Generated %u samples of %.0fHz sine wave for object %u of %s.\n",
-           samples_per_channel, frequencies[i], i + 1, element_description_tag);
+  for (int i = 0; i < num_objects; ++i) {
+    generate_sine(input_data.data + (uint32_t)i * samples_per_channel,
+                  samples_per_channel, frequencies[i], 48000.0f);
   }
 
   ret = oar_update_audio_element_data(oar, element_id, &input_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to update %s data. Error code: %d\n",
-            element_description_tag, ret);
-    free(input_data.data);
-    oar_remove_audio_element(oar, element_id);
-    return -1;
-  }
-
-  oar_metadata_t* metadata = create_object_metadata(
-      positions, num_objects_to_configure, samples_per_channel);
-  if (metadata) {
-    ret = oar_update_audio_element_metadata(oar, element_id, metadata);
-    if (ret != 0) {
-      fprintf(stderr, "Failed to update %s metadata. Error code: %d\n",
-              element_description_tag, ret);
-    } else {
-      printf("%s metadata updated for %u object(s).\n", element_description_tag,
-             num_objects_to_configure);
-      for (uint32_t i = 0; i < num_objects_to_configure; ++i) {
-        printf("  Object %u: Azimuth: %.1f, Elevation: %.1f, Distance: %.1f\n",
-               i + 1, positions[i].azimuth, positions[i].elevation,
-               positions[i].distance);
-      }
-    }
-    free(metadata);
-  } else {
-    fprintf(stderr, "Failed to create metadata for %s.\n",
-            element_description_tag);
-    free(input_data.data);
-    oar_remove_audio_element(oar, element_id);
-    return -1;
-  }
-
   free(input_data.data);
-  return 0;
+  if (ret != 0) return -1;
+
+  oar_metadata_t *metadata = create_object_metadata(
+      positions, (uint32_t)num_objects, samples_per_channel);
+  if (!metadata) return -1;
+
+  ret = oar_update_audio_element_metadata(oar, element_id, metadata);
+  free(metadata);
+  return ret;
 }
 
-// Internal helper to render audio and perform basic validation.
-// Returns 0 on success, -1 on failure. Output block must be freed by caller.
-static int _render_audio(oar_t* oar, oar_audio_block_t* output_block,
-                         const char* scenario_name_tag) {
-  printf("\n--- Rendering audio for %s ---\n", scenario_name_tag);
-  if (!oar || !output_block) {
-    fprintf(stderr, "Invalid arguments to _render_audio.\n");
-    return -1;
-  }
+/* --- Test cases --------------------------------------------------------- */
 
-  output_block->channels = oar_get_number_of_output_channels(oar);
-  output_block->samples_per_channel = oar_get_samples_per_channel(oar);
-  printf("Output channels: %u, Samples per channel: %u\n",
-         output_block->channels, output_block->samples_per_channel);
+/* TC1: Single object at 30° azimuth, 440 Hz */
+static int test_single_object(void) {
+  TEST_START("TC1: single object rendering");
 
-  output_block->data =
-      (float*)malloc(output_block->channels *
-                     output_block->samples_per_channel * sizeof(float));
-  if (output_block->data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for output audio data (%s).\n",
-            scenario_name_tag);
-    return -1;
-  }
-  memset(output_block->data, 0,
-         output_block->channels * output_block->samples_per_channel *
-             sizeof(float));
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  int ret = oar_render(oar, output_block);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to render audio for %s. Error code: %d\n",
-            scenario_name_tag, ret);
-    free(output_block->data);   // Free allocated data before returning error
-    output_block->data = NULL;  // Mark as freed
-    return -1;
-  }
-  printf("Audio for %s rendered successfully to %u channels.\n",
-         scenario_name_tag, output_block->channels);
-
-  int is_silent = 1;
-  for (uint32_t i = 0;
-       i < output_block->channels * output_block->samples_per_channel; ++i) {
-    if (fabs(output_block->data[i]) > 1e-9) {
-      is_silent = 0;
-      break;
-    }
-  }
-  if (is_silent) {
-    printf("Warning: Rendered output for %s is silent.\n", scenario_name_tag);
-  } else {
-    printf("Rendered output for %s contains audio.\n", scenario_name_tag);
-  }
-  return 0;
-}
-
-// Internal helper to print first few samples of an audio block.
-static void _print_audio_block_samples(const oar_audio_block_t* block,
-                                       const char* block_name_tag) {
-  printf("\n--- First 5 samples for %s ---\n", block_name_tag);
-  if (!block || !block->data) {
-    printf("Block is NULL or has no data.\n");
-    return;
-  }
-  for (uint32_t ch = 0; ch < block->channels; ++ch) {
-    printf("Channel %u:\n", ch);
-    for (int i = 0; i < 5; ++i) {
-      printf("  %f\n", block->data[ch * block->samples_per_channel + i]);
-    }
-  }
-}
-
-void run_single_object_test(oar_t* oar) {
-  printf("\n--- Case 1: Rendering a single object ---\n");
-  polar_t position = {30.0, 10.0, 1.0};
+  polar_t position = {30.0f, 10.0f, 1.0f};
   float frequency = 440.0f;
-  if (_add_object_element(oar, 1, 1, "Single Object", 1, &position,
-                          &frequency) != 0) {
-    fprintf(stderr, "Failed to set up single object test case.\n");
-  }
+  TEST_ASSERT(
+      add_object_element_with_data(oar, 1, 1, &position, &frequency) == 0,
+      "failed to add object element with data");
+
+  uint32_t out_ch = oar_get_number_of_output_channels(oar);
+  uint32_t spc = oar_get_samples_per_channel(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(alloc_audio_block(out_ch, spc, &output) == 0,
+              "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
 }
 
-void run_two_objects_test(oar_t* oar) {
-  printf(
-      "\n--- Case 2: Rendering a dual-mono object element (two objects) ---\n");
-  polar_t positions[2] = {{-45.0, 0.0, 1.0}, {45.0, 0.0, 1.0}};
+/* TC2: Two objects in one element (dual-mono) at ±45° */
+static int test_two_objects_one_element(void) {
+  TEST_START("TC2: two objects in one element");
+
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  polar_t positions[2] = {{-45.0f, 0.0f, 1.0f}, {45.0f, 0.0f, 1.0f}};
   float frequencies[2] = {660.0f, 880.0f};
-  if (_add_object_element(oar, 2, 2, "Dual-Mono Object Element", 2, positions,
-                          frequencies) != 0) {
-    fprintf(stderr, "Failed to set up dual-mono object test case.\n");
-  }
+  TEST_ASSERT(
+      add_object_element_with_data(oar, 2, 2, positions, frequencies) == 0,
+      "failed to add dual-object element with data");
+
+  uint32_t out_ch = oar_get_number_of_output_channels(oar);
+  uint32_t spc = oar_get_samples_per_channel(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(alloc_audio_block(out_ch, spc, &output) == 0,
+              "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
 }
 
-void run_two_single_objects_in_separate_elements_test(oar_t* oar) {
-  printf(
-      "\n--- Case 3: Rendering two single objects in separate elements ---\n");
+/* TC3: Two single-object elements in separate groups */
+static int test_two_objects_separate_elements(void) {
+  TEST_START("TC3: two objects in separate elements");
 
-  // --- Object 1 (660Hz, Azimuth -45.0) ---
-  polar_t position_1 = {-45.0, 0.0, 1.0};
-  float frequency_1 = 660.0f;
-  if (_add_object_element(oar, 3, 1, "Single Object 1 (of two separate)", 1,
-                          &position_1, &frequency_1) != 0) {
-    fprintf(
-        stderr,
-        "Failed to set up first single object for separate elements test.\n");
-    // No need to return here, the helper should clean up. If it failed, we just
-    // try the next or let main fail.
-  }
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // --- Object 2 (880Hz, Azimuth 45.0) ---
-  polar_t position_2 = {45.0, 0.0, 1.0};
-  float frequency_2 = 880.0f;
-  if (_add_object_element(oar, 4, 1, "Single Object 2 (of two separate)", 1,
-                          &position_2, &frequency_2) != 0) {
-    fprintf(
-        stderr,
-        "Failed to set up second single object for separate elements test.\n");
-  }
+  /* Element 1: 660 Hz at -45° */
+  polar_t pos1 = {-45.0f, 0.0f, 1.0f};
+  float freq1 = 660.0f;
+  TEST_ASSERT(add_object_element_with_data(oar, 3, 1, &pos1, &freq1) == 0,
+              "failed to add element 1");
+
+  /* Element 2: 880 Hz at +45° */
+  polar_t pos2 = {45.0f, 0.0f, 1.0f};
+  float freq2 = 880.0f;
+  TEST_ASSERT(add_object_element_with_data(oar, 4, 1, &pos2, &freq2) == 0,
+              "failed to add element 2");
+
+  uint32_t out_ch = oar_get_number_of_output_channels(oar);
+  uint32_t spc = oar_get_samples_per_channel(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(alloc_audio_block(out_ch, spc, &output) == 0,
+              "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
 }
 
-// Test edge case: animated object positions
-void run_animated_object_test(oar_t* oar) {
-  printf("\n--- Case 4: Rendering animated object positions ---\n");
+/* TC4: Animated object positions (−45° → +45°) */
+static int test_animated_object(void) {
+  TEST_START("TC4: animated object positions");
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr,
-            "Failed to add audio group for animated test. Error code: %d\n",
-            group_id);
-    return;
-  }
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  oar_audio_element_config_t element_cfg;
-  element_cfg.type = ck_object_based;
-  element_cfg.obc.num_objects = 1;
-  memset(&element_cfg.parameters, 0, sizeof(parameter_set_t));
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  int ret = oar_add_audio_element(oar, group_id, 5, &element_cfg);
-  if (ret != 0) {
-    fprintf(stderr,
-            "Failed to add animated object audio element. Error code: %d\n",
-            ret);
-    return;
-  }
+  oar_audio_element_config_t element_cfg = create_object_element_config(1);
+  int ret = oar_add_audio_element(oar, gid, 5, &element_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
-  uint32_t samples_per_channel = oar_get_samples_per_channel(oar);
+  uint32_t spc = oar_get_samples_per_channel(oar);
+
+  /* Feed sine data */
   oar_audio_block_t input_data;
-  input_data.channels = 1;
-  input_data.samples_per_channel = samples_per_channel;
-  input_data.data = (float*)malloc(samples_per_channel * sizeof(float));
-
-  if (!input_data.data) {
-    fprintf(stderr,
-            "Failed to allocate memory for animated test input data.\n");
-    return;
-  }
-
-  generate_sine_wave(input_data.data, samples_per_channel, 440.0f, 48000.0);
-
+  TEST_ASSERT(alloc_audio_block(1, spc, &input_data) == 0,
+              "alloc_audio_block failed");
+  generate_sine(input_data.data, spc, 440.0f, 48000.0f);
   ret = oar_update_audio_element_data(oar, 5, &input_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to update animated test data. Error code: %d\n",
-            ret);
-    free(input_data.data);
-    return;
-  }
-
-  // Create animated metadata: object moves from -45° to +45° azimuth
-  polar_t start_pos = {-45.0, 0.0, 1.0};
-  polar_t end_pos = {45.0, 0.0, 1.0};
-  oar_metadata_t* metadata = create_animated_object_metadata(
-      &start_pos, &end_pos, 1, samples_per_channel);
-
-  if (metadata) {
-    ret = oar_update_audio_element_metadata(oar, 5, metadata);
-    if (ret != 0) {
-      fprintf(stderr, "Failed to update animated metadata. Error code: %d\n",
-              ret);
-    } else {
-      printf(
-          "Animated metadata updated: object moves from azimuth %.1f° to "
-          "%.1f°\n",
-          start_pos.azimuth, end_pos.azimuth);
-    }
-    free(metadata);
-  }
-
   free(input_data.data);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_data failed");
+
+  /* Attach animated metadata */
+  polar_t start_pos = {-45.0f, 0.0f, 1.0f};
+  polar_t end_pos = {45.0f, 0.0f, 1.0f};
+  oar_metadata_t *metadata =
+      create_animated_object_metadata(&start_pos, &end_pos, 1, spc);
+  TEST_ASSERT(metadata != NULL, "create_animated_object_metadata failed");
+  ret = oar_update_audio_element_metadata(oar, 5, metadata);
+  free(metadata);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_metadata failed");
+
+  /* Render and verify */
+  uint32_t out_ch = oar_get_number_of_output_channels(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(alloc_audio_block(out_ch, spc, &output) == 0,
+              "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
 }
 
-// Test edge case: object with gain
-void run_object_with_gain_test(oar_t* oar) {
-  printf("\n--- Case 5: Rendering object with gain ---\n");
+/* TC5: Object with gain metadata (−6 dB) */
+static int test_object_with_gain(void) {
+  TEST_START("TC5: object with gain");
 
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Failed to add audio group for gain test. Error code: %d\n",
-            group_id);
-    return;
-  }
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  oar_audio_element_config_t element_cfg;
-  element_cfg.type = ck_object_based;
-  element_cfg.obc.num_objects = 1;
-  memset(&element_cfg.parameters, 0, sizeof(parameter_set_t));
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  int ret = oar_add_audio_element(oar, group_id, 6, &element_cfg);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to add gain test audio element. Error code: %d\n",
-            ret);
-    return;
-  }
+  oar_audio_element_config_t element_cfg = create_object_element_config(1);
+  int ret = oar_add_audio_element(oar, gid, 6, &element_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
-  uint32_t samples_per_channel = oar_get_samples_per_channel(oar);
+  uint32_t spc = oar_get_samples_per_channel(oar);
+
+  /* Feed sine data */
   oar_audio_block_t input_data;
-  input_data.channels = 1;
-  input_data.samples_per_channel = samples_per_channel;
-  input_data.data = (float*)malloc(samples_per_channel * sizeof(float));
-
-  if (!input_data.data) {
-    fprintf(stderr, "Failed to allocate memory for gain test input data.\n");
-    return;
-  }
-
-  generate_sine_wave(input_data.data, samples_per_channel, 440.0f, 48000.0);
-
+  TEST_ASSERT(alloc_audio_block(1, spc, &input_data) == 0,
+              "alloc_audio_block failed");
+  generate_sine(input_data.data, spc, 440.0f, 48000.0f);
   ret = oar_update_audio_element_data(oar, 6, &input_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to update gain test data. Error code: %d\n", ret);
-    free(input_data.data);
-    return;
-  }
-
-  // Set object position
-  polar_t position = {0.0, 0.0, 1.0};
-  oar_metadata_t* pos_metadata =
-      create_object_metadata(&position, 1, samples_per_channel);
-
-  if (pos_metadata) {
-    ret = oar_update_audio_element_metadata(oar, 6, pos_metadata);
-    if (ret != 0) {
-      fprintf(
-          stderr,
-          "Failed to update position metadata for gain test. Error code: %d\n",
-          ret);
-    }
-    free(pos_metadata);
-  }
-
-  // Apply gain (-6.0dB, which corresponds to linear gain of 0.5)
-  oar_metadata_t* gain_metadata =
-      create_gain_metadata(1, -6.0f, samples_per_channel);
-
-  if (gain_metadata) {
-    ret = oar_update_audio_element_metadata(oar, 6, gain_metadata);
-    if (ret != 0) {
-      fprintf(stderr, "Failed to update gain metadata. Error code: %d\n", ret);
-    } else {
-      printf("Gain metadata updated: gain = -6.0dB (linear gain ≈ 0.5)\n");
-    }
-    free(gain_metadata);
-  }
-
   free(input_data.data);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_data failed");
+
+  /* Set position metadata */
+  polar_t position = {0.0f, 0.0f, 1.0f};
+  oar_metadata_t *pos_metadata = create_object_metadata(&position, 1, spc);
+  TEST_ASSERT(pos_metadata != NULL, "create_object_metadata failed");
+  ret = oar_update_audio_element_metadata(oar, 6, pos_metadata);
+  free(pos_metadata);
+  TEST_ASSERT(ret == 0, "position metadata update failed");
+
+  /* Apply gain (−6.0 dB) */
+  oar_metadata_t *gain_metadata = create_gain_metadata(1, -6.0f, spc);
+  TEST_ASSERT(gain_metadata != NULL, "create_gain_metadata failed");
+  ret = oar_update_audio_element_metadata(oar, 6, gain_metadata);
+  free(gain_metadata);
+  TEST_ASSERT(ret == 0, "gain metadata update failed");
+
+  /* Render and verify */
+  uint32_t out_ch = oar_get_number_of_output_channels(oar);
+  oar_audio_block_t output;
+  TEST_ASSERT(alloc_audio_block(out_ch, spc, &output) == 0,
+              "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+  free(output.data);
+  oar_destroy(oar);
+
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
 }
 
-// Test edge case: invalid parameters (should be handled gracefully)
-void run_invalid_parameter_test(oar_t* oar) {
-  printf("\n--- Case 6: Testing invalid parameter handling ---\n");
+/* TC6: Invalid parameters — NULL metadata and non-existent element ID */
+static int test_invalid_parameters(void) {
+  TEST_START("TC6: invalid parameter handling");
 
-  // Test with NULL metadata (should be handled gracefully)
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
+
+  /* NULL metadata should be rejected */
   int ret = oar_update_audio_element_metadata(oar, 99, NULL);
-  if (ret != 0) {
-    printf("Correctly rejected NULL metadata (error code: %d)\n", ret);
-  } else {
-    printf("WARNING: NULL metadata was accepted (potential bug)\n");
-  }
+  TEST_ASSERT(ret != 0, "NULL metadata was accepted");
 
-  // Test with non-existent element ID
+  /* Non-existent element ID should be rejected */
   oar_metadata_t dummy_metadata;
+  memset(&dummy_metadata, 0, sizeof(dummy_metadata));
   dummy_metadata.type = ck_metadata_object_positions;
   dummy_metadata.duration = 256;
   ret = oar_update_audio_element_metadata(oar, 999, &dummy_metadata);
-  if (ret != 0) {
-    printf("Correctly rejected non-existent element ID (error code: %d)\n",
-           ret);
-  } else {
-    printf("WARNING: Non-existent element ID was accepted (potential bug)\n");
-  }
+  TEST_ASSERT(ret != 0, "non-existent element ID was accepted");
+
+  oar_destroy(oar);
+  return TEST_PASS;
 }
 
-// Helper function to compare two audio blocks
-void compare_audio_blocks(const oar_audio_block_t* block1,
-                          const oar_audio_block_t* block2,
-                          const char* block1_name, const char* block2_name) {
-  printf("\n--- Comparing Audio Blocks: %s vs %s ---\n", block1_name,
-         block2_name);
-  if (block1->channels != block2->channels ||
-      block1->samples_per_channel != block2->samples_per_channel) {
-    printf("Error: Audio blocks have different dimensions.\n");
-    printf("%s: channels=%u, samples_per_channel=%u\n", block1_name,
-           block1->channels, block1->samples_per_channel);
-    printf("%s: channels=%u, samples_per_channel=%u\n", block2_name,
-           block2->channels, block2->samples_per_channel);
-    return;
-  }
+/* --- Test table --------------------------------------------------------- */
 
-  uint32_t total_samples = block1->channels * block1->samples_per_channel;
-  double max_diff = 0.0;
-  double sum_sq_diff = 0.0;
-  double sample1_val, sample2_val, diff;
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "single object", test_single_object),
+    TEST_ENTRY("TC2", "two objects in one element",
+               test_two_objects_one_element),
+    TEST_ENTRY("TC3", "two objects in separate elements",
+               test_two_objects_separate_elements),
+    TEST_ENTRY("TC4", "animated object positions", test_animated_object),
+    TEST_ENTRY("TC5", "object with gain", test_object_with_gain),
+    TEST_ENTRY("TC6", "invalid parameters", test_invalid_parameters),
+};
 
-  for (uint32_t i = 0; i < total_samples; ++i) {
-    sample1_val = block1->data[i];
-    sample2_val = block2->data[i];
-    diff = fabs(sample1_val - sample2_val);
-    if (diff > max_diff) {
-      max_diff = diff;
-    }
-    sum_sq_diff += diff * diff;
-  }
-  double mean_sq_error = sum_sq_diff / total_samples;
-
-  printf("Total samples compared: %u\n", total_samples);
-  printf("Maximum absolute difference: %f\n", max_diff);
-  printf("Mean Squared Error (MSE): %f\n", mean_sq_error);
-
-  if (max_diff < 1e-6) {  // A small threshold for floating point comparison
-    printf("Result: Audio blocks are effectively identical.\n");
-  } else {
-    printf("Result: Audio blocks have significant differences.\n");
-  }
-}
-
-int main() {
-  printf("Running object-based audio element rendering test...\n");
-  oar_config_t oar_cfg = create_default_oar_config();
-  oar_audio_block_t output_data_single_object = {0};
-  oar_audio_block_t output_data_case_a = {0};
-  oar_audio_block_t output_data_case_b = {0};
-  oar_audio_block_t output_data_animated = {0};
-  oar_audio_block_t output_data_gain = {0};
-
-  // --- Scenario 0: Single object ---
-  printf("\n===== Scenario 0: Single Object =====\n");
-  oar_t* oar_single = oar_create(&oar_cfg);
-  if (oar_single == NULL) {
-    fprintf(stderr, "Failed to create OAR object for Single Object test.\n");
-    return -1;
-  }
-  printf("OAR object for Single Object test created successfully.\n");
-
-  run_single_object_test(oar_single);
-
-  if (_render_audio(oar_single, &output_data_single_object,
-                    "Single Object Scenario") != 0) {
-    fprintf(stderr,
-            "Aborting due to rendering failure in Single Object test.\n");
-    oar_destroy(oar_single);
-    // output_data_single_object.data is freed by _render_audio on failure, or
-    // NULL
-    return -1;
-  }
-  oar_destroy(oar_single);  // Destroy OAR instance for Single Object test
-  _print_audio_block_samples(&output_data_single_object,
-                             "Single Object Output");
-
-  // --- Scenario A: Two objects in a single element ---
-  printf("\n===== Scenario A: Two objects in one element =====\n");
-  oar_t* oar_case_a = oar_create(&oar_cfg);
-  if (oar_case_a == NULL) {
-    fprintf(stderr, "Failed to create OAR object for Scenario A.\n");
-    return -1;
-  }
-  printf("OAR object for Scenario A created successfully.\n");
-
-  run_two_objects_test(oar_case_a);
-
-  if (_render_audio(oar_case_a, &output_data_case_a, "Scenario A") != 0) {
-    fprintf(stderr, "Aborting due to rendering failure in Scenario A.\n");
-    oar_destroy(oar_case_a);
-    // output_data_case_a.data is freed by _render_audio on failure, or NULL
-    return -1;
-  }
-  oar_destroy(oar_case_a);  // Destroy OAR instance for Scenario A
-  _print_audio_block_samples(&output_data_case_a, "Scenario A Output");
-
-  // --- Scenario B: Two objects in two separate elements ---
-  printf("\n===== Scenario B: Two objects in two separate elements =====\n");
-  oar_t* oar_case_b = oar_create(&oar_cfg);
-  if (oar_case_b == NULL) {
-    fprintf(stderr, "Failed to create OAR object for Scenario B.\n");
-    free(output_data_case_a.data);  // Clean up Scenario A data
-    return -1;
-  }
-  printf("OAR object for Scenario B created successfully.\n");
-
-  run_two_single_objects_in_separate_elements_test(oar_case_b);
-
-  if (_render_audio(oar_case_b, &output_data_case_b, "Scenario B") != 0) {
-    fprintf(stderr, "Aborting due to rendering failure in Scenario B.\n");
-    oar_destroy(oar_case_b);
-    free(output_data_case_a.data);  // Clean up Scenario A data
-    // output_data_case_b.data is freed by _render_audio on failure, or NULL
-    return -1;
-  }
-  oar_destroy(oar_case_b);  // Destroy OAR instance for Scenario B
-  _print_audio_block_samples(&output_data_case_b, "Scenario B Output");
-
-  // --- Scenario C: Animated object positions ---
-  printf("\n===== Scenario C: Animated object positions =====\n");
-  oar_t* oar_animated = oar_create(&oar_cfg);
-  if (oar_animated == NULL) {
-    fprintf(stderr, "Failed to create OAR object for animated test.\n");
-    free(output_data_case_a.data);
-    free(output_data_case_b.data);
-    return -1;
-  }
-  printf("OAR object for animated test created successfully.\n");
-
-  run_animated_object_test(oar_animated);
-
-  if (_render_audio(oar_animated, &output_data_animated, "Animated Scenario") !=
-      0) {
-    fprintf(stderr, "Aborting due to rendering failure in animated test.\n");
-    oar_destroy(oar_animated);
-    free(output_data_case_a.data);
-    free(output_data_case_b.data);
-    return -1;
-  }
-  oar_destroy(oar_animated);
-  _print_audio_block_samples(&output_data_animated, "Animated Output");
-
-  // --- Scenario D: Object with gain ---
-  printf("\n===== Scenario D: Object with gain =====\n");
-  oar_t* oar_gain = oar_create(&oar_cfg);
-  if (oar_gain == NULL) {
-    fprintf(stderr, "Failed to create OAR object for gain test.\n");
-    free(output_data_case_a.data);
-    free(output_data_case_b.data);
-    free(output_data_animated.data);
-    return -1;
-  }
-  printf("OAR object for gain test created successfully.\n");
-
-  run_object_with_gain_test(oar_gain);
-
-  if (_render_audio(oar_gain, &output_data_gain, "Gain Scenario") != 0) {
-    fprintf(stderr, "Aborting due to rendering failure in gain test.\n");
-    oar_destroy(oar_gain);
-    free(output_data_case_a.data);
-    free(output_data_case_b.data);
-    free(output_data_animated.data);
-    return -1;
-  }
-  oar_destroy(oar_gain);
-  _print_audio_block_samples(&output_data_gain, "Gain Output");
-
-  // --- Scenario E: Invalid parameter test ---
-  printf("\n===== Scenario E: Invalid parameter test =====\n");
-  oar_t* oar_invalid = oar_create(&oar_cfg);
-  if (oar_invalid == NULL) {
-    fprintf(stderr,
-            "Failed to create OAR object for invalid parameter test.\n");
-    free(output_data_case_a.data);
-    free(output_data_case_b.data);
-    free(output_data_animated.data);
-    free(output_data_gain.data);
-    return -1;
-  }
-  printf("OAR object for invalid parameter test created successfully.\n");
-
-  run_invalid_parameter_test(oar_invalid);
-  oar_destroy(oar_invalid);
-
-  // --- Comparison ---
-  compare_audio_blocks(&output_data_case_a, &output_data_case_b,
-                       "Scenario A (Two objects in one element)",
-                       "Scenario B (Two objects in two separate elements)");
-
-  // --- Cleanup ---
-  free(output_data_single_object.data);
-  free(output_data_case_a.data);
-  free(output_data_case_b.data);
-  free(output_data_animated.data);
-  free(output_data_gain.data);
-
-  printf("\nObject-based rendering test completed.\n");
-  return 0;
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }

--- a/tests/examples/test_remove_audio_element.c
+++ b/tests/examples/test_remove_audio_element.c
@@ -6,7 +6,7 @@
  * License was not distributed with this source code in the LICENSE file, you
  * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
  * Alliance for Open Media Patent License 1.0 was not distributed with this
- * source code in the PATENTS file, you can obtain it at
+ * source code in the LICENSE file, you can obtain it at
  * www.aomedia.org/license/patent.
  */
 
@@ -16,7 +16,7 @@
  * Scenarios:
  *   1. Non-binaural: Add then remove a single element, verify count=0
  *   2. Non-binaural: Add multiple elements, remove one, verify remaining
- * renders
+ *      renders
  *   3. Non-binaural: Add, remove, re-add element
  *   4. Binaural: Attempt non-LIFO removal (should fail, elements remain active)
  *   5. Binaural: LIFO remove one, then remove all, verify renderer retained and
@@ -28,36 +28,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 #include "oar.h"
 #include "oar_base.h"
 #include "test_framework.h"
-
-static oar_config_t create_stereo_config(void) {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_stereo;
-  config.samples_per_channel = 256;
-  config.sampling_rate = 48000;
-  return config;
-}
-
-static oar_config_t create_binaural_config(void) {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_binaural;
-  config.samples_per_channel = 256;
-  config.sampling_rate = 48000;
-  return config;
-}
-
-static void generate_sine(float *buffer, uint32_t samples, uint32_t channels,
-                          uint32_t ch_idx, float freq, float sr) {
-  for (uint32_t i = 0; i < samples; i++)
-    buffer[ch_idx * samples + i] =
-        (float)sin(2.0 * M_PI * freq * ((float)i / sr));
-}
+#include "test_helpers.h"
 
 /* Feed sine wave to element, render, and verify output is non-silent.
  * Returns 0 on success (non-silent), -1 on failure. */
@@ -68,23 +42,17 @@ static int render_and_verify_non_silent(oar_t *oar, uint32_t element_id,
   uint32_t output_ch = oar_get_number_of_output_channels(oar);
 
   oar_audio_block_t input;
-  input.channels = element_channels;
-  input.samples_per_channel = samples;
-  input.data = (float *)calloc(element_channels * samples, sizeof(float));
-  if (!input.data) return -1;
+  if (alloc_audio_block(element_channels, samples, &input) != 0) return -1;
 
-  generate_sine(input.data, samples, element_channels, 0, 440.0f,
-                (float)cfg->sampling_rate);
+  generate_sine_channel(input.data, samples, element_channels, 0, 440.0f,
+                        (float)cfg->sampling_rate);
 
   int ret = oar_update_audio_element_data(oar, element_id, &input);
   free(input.data);
   if (ret != 0) return -1;
 
   oar_audio_block_t output;
-  output.channels = output_ch;
-  output.samples_per_channel = samples;
-  output.data = (float *)calloc(output_ch * samples, sizeof(float));
-  if (!output.data) return -1;
+  if (alloc_audio_block(output_ch, samples, &output) != 0) return -1;
 
   ret = oar_render(oar, &output);
   if (ret != 0) {
@@ -92,32 +60,24 @@ static int render_and_verify_non_silent(oar_t *oar, uint32_t element_id,
     return -1;
   }
 
-  int is_silent = 1;
-  for (uint32_t i = 0; i < output_ch * samples; i++) {
-    if (fabsf(output.data[i]) > 1e-9f) {
-      is_silent = 0;
-      break;
-    }
-  }
+  int silent = !is_output_non_silent(output.data, output_ch * samples);
   free(output.data);
-  return is_silent ? -1 : 0;
+  return silent ? -1 : 0;
 }
 
 /* Scenario 1: Non-binaural — Add then remove a single element */
 static int test_remove_single_element(void) {
   TEST_START("test_remove_single_element");
 
-  oar_config_t cfg = create_stereo_config();
+  oar_config_t cfg = create_config(ck_oar_layout_stereo, 256, 48000);
   oar_t *oar = oar_create(&cfg);
   TEST_ASSERT(oar != NULL, "oar_create failed");
 
   int gid = oar_add_audio_group(oar);
   TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_channel_based;
-  elem_cfg.cbc.layout = ck_oar_layout_mono;
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
 
   int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
   TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
@@ -147,17 +107,15 @@ static int test_remove_single_element(void) {
 static int test_remove_one_of_multiple_elements(void) {
   TEST_START("test_remove_one_of_multiple_elements");
 
-  oar_config_t cfg = create_stereo_config();
+  oar_config_t cfg = create_config(ck_oar_layout_stereo, 256, 48000);
   oar_t *oar = oar_create(&cfg);
   TEST_ASSERT(oar != NULL, "oar_create failed");
 
   int gid = oar_add_audio_group(oar);
   TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_channel_based;
-  elem_cfg.cbc.layout = ck_oar_layout_mono;
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
 
   int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
   TEST_ASSERT(ret == 0, "add element 1 failed");
@@ -193,17 +151,15 @@ static int test_remove_one_of_multiple_elements(void) {
 static int test_readd_after_remove(void) {
   TEST_START("test_readd_after_remove");
 
-  oar_config_t cfg = create_stereo_config();
+  oar_config_t cfg = create_config(ck_oar_layout_stereo, 256, 48000);
   oar_t *oar = oar_create(&cfg);
   TEST_ASSERT(oar != NULL, "oar_create failed");
 
   int gid = oar_add_audio_group(oar);
   TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_channel_based;
-  elem_cfg.cbc.layout = ck_oar_layout_mono;
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
 
   int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
   TEST_ASSERT(ret == 0, "add element failed");
@@ -225,7 +181,7 @@ static int test_readd_after_remove(void) {
 static int test_binaural_remove_non_lifo(void) {
   TEST_START("test_binaural_remove_non_lifo");
 
-  oar_config_t cfg = create_binaural_config();
+  oar_config_t cfg = create_config(ck_oar_layout_binaural, 256, 48000);
   oar_t *oar = oar_create(&cfg);
   if (!oar) {
     printf("SKIP: binaural not supported\n");
@@ -235,10 +191,8 @@ static int test_binaural_remove_non_lifo(void) {
   int gid = oar_add_audio_group(oar);
   TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_channel_based;
-  elem_cfg.cbc.layout = ck_oar_layout_mono;
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
 
   int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
   TEST_ASSERT(ret == 0, "add element 1 failed");
@@ -276,7 +230,7 @@ static int test_binaural_remove_non_lifo(void) {
 static int test_binaural_remove_all_and_readd(void) {
   TEST_START("test_binaural_remove_all_and_readd");
 
-  oar_config_t cfg = create_binaural_config();
+  oar_config_t cfg = create_config(ck_oar_layout_binaural, 256, 48000);
   oar_t *oar = oar_create(&cfg);
   if (!oar) {
     printf("SKIP: binaural not supported\n");
@@ -286,10 +240,8 @@ static int test_binaural_remove_all_and_readd(void) {
   int gid = oar_add_audio_group(oar);
   TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  oar_audio_element_config_t elem_cfg;
-  memset(&elem_cfg, 0, sizeof(elem_cfg));
-  elem_cfg.type = ck_channel_based;
-  elem_cfg.cbc.layout = ck_oar_layout_mono;
+  oar_audio_element_config_t elem_cfg =
+      create_channel_element_config(ck_oar_layout_mono);
 
   int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
   TEST_ASSERT(ret == 0, "add element 1 failed");
@@ -310,8 +262,9 @@ static int test_binaural_remove_all_and_readd(void) {
 
   /* Step 2: Remove element 1 (now the last), verify renderer is retained.
    * The binaural renderer is NOT destroyed when all elements are removed —
-   * its lifecycle is tied to the audio group. oar_get_number_of_audio_elements
-   * returns the actual element count (0 = no elements, but renderer exists). */
+   * its lifecycle is tied to the audio group. After removing all elements,
+   * the element count should be 0 (the renderer itself is retained but has
+   * no elements). */
   ret = oar_remove_audio_element(oar, 1);
   TEST_ASSERT(ret == 0, "remove element 1 failed");
 

--- a/tests/examples/test_remove_audio_element.c
+++ b/tests/examples/test_remove_audio_element.c
@@ -21,6 +21,9 @@
  *   4. Binaural: Attempt non-LIFO removal (should fail, elements remain active)
  *   5. Binaural: LIFO remove one, then remove all, verify renderer retained and
  *      re-add works with rendering
+ *   6. Binaural: Head rotation state preserved after remove-all + re-add
+ *   7. Binaural: Without head tracking, remove-all + re-add produces identical
+ *      output (baseline for TC6)
  */
 
 #include <math.h>
@@ -63,6 +66,45 @@ static int render_and_verify_non_silent(oar_t *oar, uint32_t element_id,
   int silent = !is_output_non_silent(output.data, output_ch * samples);
   free(output.data);
   return silent ? -1 : 0;
+}
+
+/* --- Head rotation test helpers ----------------------------------------- */
+
+/* Feed stimulus to element, render, and capture output.
+ * Returns 0 on success, -1 on failure. Caller must free out->data. */
+static int render_and_capture(oar_t *oar, uint32_t element_id,
+                              uint32_t element_channels,
+                              const oar_config_t *cfg, oar_audio_block_t *out) {
+  uint32_t samples = oar_get_samples_per_channel(oar);
+  uint32_t output_ch = oar_get_number_of_output_channels(oar);
+
+  oar_audio_block_t input;
+  if (alloc_audio_block(element_channels, samples, &input) != 0) return -1;
+
+  for (uint32_t c = 0; c < element_channels; c++)
+    generate_dual_tone_stimulus(input.data + c * samples, samples,
+                                (float)cfg->sampling_rate, 440.0f, 3500.0f);
+
+  int ret = oar_update_audio_element_data(oar, element_id, &input);
+  free(input.data);
+  if (ret != 0) return -1;
+
+  if (alloc_audio_block(output_ch, samples, out) != 0) return -1;
+
+  ret = oar_render(oar, out);
+  if (ret != 0) {
+    free(out->data);
+    return -1;
+  }
+
+  return 0;
+}
+
+/* Sum of absolute differences between two float buffers. */
+static double sum_abs_diff(const float *a, const float *b, uint32_t count) {
+  double sum = 0.0;
+  for (uint32_t i = 0; i < count; ++i) sum += fabs((double)a[i] - (double)b[i]);
+  return sum;
 }
 
 /* Scenario 1: Non-binaural — Add then remove a single element */
@@ -290,6 +332,128 @@ static int test_binaural_remove_all_and_readd(void) {
   return TEST_PASS;
 }
 
+/* Scenario 6 & 7: Binaural — remove-all + re-add determinism.
+ *
+ * Shared implementation for TC6 (with head tracking) and TC7 (without).
+ *
+ * When head_tracking is enabled, verifies that head rotation state is
+ * preserved across remove-all + re-add.
+ * When head_tracking is disabled, verifies that re-add produces
+ * identical output (baseline for the head rotation test). */
+static int test_binaural_readd_determinism(int head_tracking) {
+  oar_config_t cfg = create_config(ck_oar_layout_binaural, 256, 48000);
+  oar_t *oar = oar_create(&cfg);
+  if (!oar) {
+    printf("SKIP: binaural not supported\n");
+    return TEST_PASS;
+  }
+
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
+
+  if (head_tracking) {
+    int ret = oar_enable_head_tracking(oar, 1);
+    TEST_ASSERT(ret == 0, "oar_enable_head_tracking failed");
+
+    /* Set 90° yaw rotation: quaternion (cos(45°), 0, sin(45°), 0) */
+    oar_metadata_t rot_meta;
+    memset(&rot_meta, 0, sizeof(rot_meta));
+    rot_meta.type = ck_metadata_head_rotation;
+    rot_meta.head_rotation.w = (float)cos(M_PI / 4.0);
+    rot_meta.head_rotation.x = 0.0f;
+    rot_meta.head_rotation.y = (float)sin(M_PI / 4.0);
+    rot_meta.head_rotation.z = 0.0f;
+    rot_meta.duration = 0;
+
+    ret = oar_update_metadata(oar, gid, &rot_meta);
+    TEST_ASSERT(ret == 0, "oar_update_metadata for head rotation failed");
+  }
+
+  /* Add object element at 45° azimuth (non-center position for meaningful
+   * binaural rendering; rotation effect only applies when head_tracking=1) */
+  oar_audio_element_config_t elem_cfg = create_object_element_config(1);
+  int ret = oar_add_audio_element(oar, gid, 1, &elem_cfg);
+  TEST_ASSERT(ret == 0, "add element failed");
+
+  polar_t pos = {45.0f, 0.0f, 1.0f};
+  oar_metadata_t *pos_meta = create_object_metadata(&pos, 1, 256);
+  TEST_ASSERT(pos_meta != NULL, "create_object_metadata failed");
+  ret = oar_update_audio_element_metadata(oar, 1, pos_meta);
+  free(pos_meta);
+  TEST_ASSERT(ret == 0, "set object position failed");
+
+  /* Render — output A */
+  uint32_t ch = oar_get_number_of_audio_element_channels(oar, 1);
+  TEST_ASSERT(ch > 0, "element should have channels");
+
+  oar_audio_block_t out_a;
+  TEST_ASSERT(render_and_capture(oar, 1, ch, &cfg, &out_a) == 0,
+              "render A failed");
+
+  /* Remove all elements — OBR handle will be recreated on next add */
+  ret = oar_remove_audio_element(oar, 1);
+  TEST_ASSERT(ret == 0, "remove element failed");
+
+  TEST_ASSERT(oar_get_number_of_audio_elements(oar) == 0,
+              "element count should be 0");
+
+  /* Re-add element and set same position */
+  ret = oar_add_audio_element(oar, gid, 2, &elem_cfg);
+  TEST_ASSERT(ret == 0, "re-add element failed");
+
+  pos_meta = create_object_metadata(&pos, 1, 256);
+  TEST_ASSERT(pos_meta != NULL, "create_object_metadata failed (re-add)");
+  ret = oar_update_audio_element_metadata(oar, 2, pos_meta);
+  free(pos_meta);
+  TEST_ASSERT(ret == 0, "set object position failed (re-add)");
+
+  /* Render — output B */
+  ch = oar_get_number_of_audio_element_channels(oar, 2);
+  TEST_ASSERT(ch > 0, "re-added element should have channels");
+
+  oar_audio_block_t out_b;
+  TEST_ASSERT(render_and_capture(oar, 2, ch, &cfg, &out_b) == 0,
+              "render B failed");
+
+  /* Compare outputs A and B */
+  uint32_t total = out_a.channels * out_a.samples_per_channel;
+  double diff = sum_abs_diff(out_a.data, out_b.data, total);
+
+  double signal_level = 0.0;
+  if (head_tracking) {
+    for (uint32_t i = 0; i < total; ++i)
+      signal_level += fabs((double)out_a.data[i]);
+  }
+
+  free(out_a.data);
+  free(out_b.data);
+
+  if (head_tracking) {
+    printf("  diff=%.6f, signal=%.6f, ratio=%.6f\n", diff, signal_level,
+           signal_level > 0 ? diff / signal_level : 0.0);
+    TEST_ASSERT(signal_level > 0, "signal level should be non-zero");
+    TEST_ASSERT(diff / signal_level < 0.01,
+                "head rotation state lost: outputs differ after re-add");
+  } else {
+    printf("  diff=%.6f\n", diff);
+    TEST_ASSERT(diff < 1e-4,
+                "outputs should be identical without head tracking");
+  }
+
+  oar_destroy(oar);
+  return TEST_PASS;
+}
+
+static int test_binaural_head_rotation_preserved_on_readd(void) {
+  TEST_START("test_binaural_head_rotation_preserved_on_readd");
+  return test_binaural_readd_determinism(1);
+}
+
+static int test_binaural_no_tracking_readd_identical(void) {
+  TEST_START("test_binaural_no_tracking_readd_identical");
+  return test_binaural_readd_determinism(0);
+}
+
 /* --- Test table --------------------------------------------------------- */
 
 static test_entry_t g_tests[] = {
@@ -301,6 +465,10 @@ static test_entry_t g_tests[] = {
                test_binaural_remove_non_lifo),
     TEST_ENTRY("TC5", "binaural remove all and re-add",
                test_binaural_remove_all_and_readd),
+    TEST_ENTRY("TC6", "binaural head rotation preserved on re-add",
+               test_binaural_head_rotation_preserved_on_readd),
+    TEST_ENTRY("TC7", "binaural no tracking re-add identical",
+               test_binaural_no_tracking_readd_identical),
 };
 
 int main(int argc, char *argv[]) {

--- a/tests/examples/test_scene_based_rendering.c
+++ b/tests/examples/test_scene_based_rendering.c
@@ -10,194 +10,99 @@
  * www.aomedia.org/license/patent.
  */
 
+/**
+ * @file test_scene_based_rendering.c
+ * @brief Test scene-based (1st Order Ambisonics) audio element rendering.
+ *
+ * Test matrix:
+ *   TC1: Add a 1OA scene-based element, feed ambisonics data, render, and
+ *        verify the output is non-silent.
+ */
 
-#include <math.h>  // For sine wave generation
+#include <math.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-// Include the OAR header
 #include "oar.h"
 #include "oar_base.h"
+#include "test_framework.h"
+#include "test_helpers.h"
 
-// Helper function to create a basic OAR config
-oar_config_t create_default_oar_config() {
-  oar_config_t config;
-  config.target_layout = ck_oar_layout_stereo;  // Render to stereo
-  config.samples_per_channel = 256;             // Smaller block for testing
-  config.sampling_rate = 48000;
-  return config;
-}
-
-// Helper function to generate Ambisonics data (e.g., 1st Order)
-// For 1OA, channels are W, Y, Z, X (ACN channel ordering)
-void generate_ambisonics_data(float* buffer, uint32_t samples, uint32_t order,
-                              float sample_rate) {
-  uint32_t num_channels = (order + 1) * (order + 1);
-  float freq_w = 220.0;  // Frequency for W channel (omnidirectional)
-  float freq_y = 330.0;  // Frequency for Y channel (front-back)
-  float freq_z = 440.0;  // Frequency for Z channel (up-down)
-  float freq_x = 550.0;  // Frequency for X channel (left-right)
+/* Generate 1st Order Ambisonics data (W, Y, Z, X in ACN ordering). */
+static void generate_ambisonics_data(float *buffer, uint32_t samples,
+                                     float sample_rate) {
+  float freq_w = 220.0f;
+  float freq_y = 330.0f;
+  float freq_z = 440.0f;
+  float freq_x = 550.0f;
 
   for (uint32_t i = 0; i < samples; ++i) {
     float t = (float)i / sample_rate;
-    if (num_channels > 0)
-      buffer[0 * samples + i] = (float)sin(2.0 * M_PI * freq_w * t);  // W
-    if (num_channels > 1)
-      buffer[1 * samples + i] = (float)sin(2.0 * M_PI * freq_y * t);  // Y
-    if (num_channels > 2)
-      buffer[2 * samples + i] = (float)sin(2.0 * M_PI * freq_z * t);  // Z
-    if (num_channels > 3)
-      buffer[3 * samples + i] = (float)sin(2.0 * M_PI * freq_x * t);  // X
-    // Higher orders would require more complex generation following Ambisonics
-    // principles
+    buffer[0 * samples + i] = (float)sin(2.0 * M_PI * freq_w * t);
+    buffer[1 * samples + i] = (float)sin(2.0 * M_PI * freq_y * t);
+    buffer[2 * samples + i] = (float)sin(2.0 * M_PI * freq_z * t);
+    buffer[3 * samples + i] = (float)sin(2.0 * M_PI * freq_x * t);
   }
 }
 
-int main() {
-  printf("Running scene-based audio element rendering test...\n\n");
+static int test_scene_based_rendering(void) {
+  TEST_START("TC1: scene-based rendering (1OA → stereo)");
 
-  oar_config_t oar_cfg = create_default_oar_config();
-  oar_t* oar = oar_create(&oar_cfg);
-  if (oar == NULL) {
-    fprintf(stderr, "Failed to create OAR object.\n");
-    return -1;
-  }
-  printf("OAR object created successfully.\n");
+  oar_config_t oar_cfg = create_config(ck_oar_layout_stereo, 256, 48000);
+  oar_t *oar = oar_create(&oar_cfg);
+  TEST_ASSERT(oar != NULL, "oar_create failed");
 
-  // Configure a scene-based audio element (e.g., 1st Order Ambisonics)
-  oar_audio_element_config_t element_cfg;
-  element_cfg.type = ck_scene_based;
-  element_cfg.sbc.order = ck_oar_1oa;  // Use 1st Order Ambisonics
+  int gid = oar_add_audio_group(oar);
+  TEST_ASSERT(gid >= 0, "oar_add_audio_group failed");
 
-  memset(&element_cfg.parameters, 0, sizeof(parameter_set_t));
-
-  // Add an audio group first
-  int group_id = oar_add_audio_group(oar);
-  if (group_id < 0) {
-    fprintf(stderr, "Failed to add audio group. Error code: %d\n", group_id);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio group (ID: %d) added successfully.\n", group_id);
-
+  oar_audio_element_config_t element_cfg =
+      create_scene_element_config(ck_oar_1oa);
   uint32_t element_id = 1;
-  int ret = oar_add_audio_element(oar, group_id, element_id, &element_cfg);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to add audio element. Error code: %d\n", ret);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf(
-      "Scene-based audio element (ID: %d, Order: 1OA) added to group %d "
-      "successfully.\n",
-      element_id, group_id);
+  int ret = oar_add_audio_element(oar, gid, element_id, &element_cfg);
+  TEST_ASSERT(ret == 0, "oar_add_audio_element failed");
 
   uint32_t input_channels =
       oar_get_number_of_audio_element_channels(oar, element_id);
   uint32_t output_channels = oar_get_number_of_output_channels(oar);
   uint32_t samples_per_channel = oar_get_samples_per_channel(oar);
 
-  printf(
-      "Input channels (HOA): %u, Output channels: %u, Samples per channel: "
-      "%u\n",
-      input_channels, output_channels, samples_per_channel);
-  if (input_channels != 4) {  // 1OA should have 4 channels
-    fprintf(stderr, "Error: Expected 4 input channels for 1OA, got %u.\n",
-            input_channels);
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(input_channels == 4, "expected 4 input channels for 1OA");
 
-  // Prepare input audio data (planar format)
+  /* Prepare input audio data (planar format) */
   oar_audio_block_t input_data;
-  input_data.channels = input_channels;
-  input_data.samples_per_channel = samples_per_channel;
-  input_data.data =
-      (float*)malloc(input_channels * samples_per_channel * sizeof(float));
-  if (input_data.data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for input audio data.\n");
-    oar_destroy(oar);
-    return -1;
-  }
+  TEST_ASSERT(
+      alloc_audio_block(input_channels, samples_per_channel, &input_data) == 0,
+      "alloc_audio_block failed for input data");
 
-  // Generate 1st Order Ambisonics data
   generate_ambisonics_data(input_data.data, samples_per_channel,
-                           element_cfg.sbc.order, (float)oar_cfg.sampling_rate);
-  printf("Generated %u samples of 1st Order Ambisonics data.\n",
-         samples_per_channel);
+                           (float)oar_cfg.sampling_rate);
 
-  // Update the audio element with the generated data
   ret = oar_update_audio_element_data(oar, element_id, &input_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to update audio element data. Error code: %d\n",
-            ret);
-    free(input_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio element data updated successfully.\n");
-
-  // Prepare output audio data (planar format)
-  oar_audio_block_t output_data;
-  output_data.channels = output_channels;  // Should be stereo as per oar_config
-  output_data.samples_per_channel = samples_per_channel;
-  output_data.data =
-      (float*)malloc(output_channels * samples_per_channel * sizeof(float));
-  if (output_data.data == NULL) {
-    fprintf(stderr, "Failed to allocate memory for output audio data.\n");
-    free(input_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  // Initialize output to silence
-  memset(output_data.data, 0,
-         output_channels * samples_per_channel * sizeof(float));
-
-  // Perform rendering
-  printf("Rendering audio...\n");
-  ret = oar_render(oar, &output_data);
-  if (ret != 0) {
-    fprintf(stderr, "Failed to render audio. Error code: %d\n", ret);
-    free(input_data.data);
-    free(output_data.data);
-    oar_destroy(oar);
-    return -1;
-  }
-  printf("Audio rendered successfully to %u channels.\n", output_data.channels);
-
-  // Here, one would typically save the output_data to a file or play it.
-  // For this test, we'll just verify that the output is not all silence.
-  int is_silent = 1;
-  for (uint32_t i = 0; i < output_channels * samples_per_channel; ++i) {
-    if (fabs(output_data.data[i]) > 1e-9) {  // Check if not close to zero
-      is_silent = 0;
-      break;
-    }
-  }
-
-  if (is_silent) {
-    printf("Warning: Rendered output is silent.\n");
-  } else {
-    printf("Rendered output contains audio.\n");
-  }
-
-  // Print a few samples from the first output channel for inspection
-  printf("First 5 samples of output channel 0:\n");
-  for (int i = 0; i < 5; ++i) {
-    printf("  %f\n", output_data.data[i]);
-  }
-
-  // Cleanup
   free(input_data.data);
-  free(output_data.data);
+  TEST_ASSERT(ret == 0, "oar_update_audio_element_data failed");
+
+  /* Render and verify non-silent output */
+  oar_audio_block_t output;
+  TEST_ASSERT(
+      alloc_audio_block(output_channels, samples_per_channel, &output) == 0,
+      "alloc_audio_block failed");
+
+  int result = render_and_check_non_silent(oar, &output);
+
+  free(output.data);
   oar_destroy(oar);
 
-  printf("\nScene-based rendering test completed.\n");
-  return 0;
+  TEST_ASSERT(result == 0, "render output is silent");
+  return TEST_PASS;
+}
+
+/* --- Test table --------------------------------------------------------- */
+
+static test_entry_t g_tests[] = {
+    TEST_ENTRY("TC1", "scene-based rendering", test_scene_based_rendering),
+};
+
+int main(int argc, char *argv[]) {
+  return run_all_tests(g_tests, NUM_TESTS(g_tests), argc, argv);
 }


### PR DESCRIPTION
- Add test_helpers.c/test_helpers.h with reusable utilities (config creation, signal generation, metadata helpers, output verification)
- Create oar_test_common shared library in CMake and Bazel to eliminate per-test build boilerplate
- Migrate all test files to use TEST_ASSERT/run_all_tests framework, removing ~1200 lines of duplicated error-handling code
- Fix waitpid EINTR handling in test_framework.c with retry loop