### PR TITLE
Pin pffft to the same jpommier commit in CMake and Bazel

### DIFF
--- a/src/renderer/obr/obr_capi/obr/CMakeLists.txt
+++ b/src/renderer/obr/obr_capi/obr/CMakeLists.txt
@@ -58,7 +58,7 @@ FetchContent_MakeAvailable(eigen)
 FetchContent_Declare(
         pffft
         GIT_REPOSITORY https://bitbucket.org/jpommier/pffft.git
-        GIT_TAG 180c2d62717c0150d8aebd165fce19ee4e5f86f9
+        GIT_TAG 0aec0327a6912e1a0ec5326eef737c2ce19bc836
 )
 FetchContent_MakeAvailable(pffft)
 

--- a/src/renderer/obr/obr_capi/obr/extensions.bzl
+++ b/src/renderer/obr/obr_capi/obr/extensions.bzl
@@ -4,7 +4,7 @@ def _pffft_ext_impl(mctx):
     new_git_repository(
         name = "pffft",
         remote = "https://bitbucket.org/jpommier/pffft.git",
-        commit = "d7a4c0206a29423478776d6b23a37bbb308f21d5",
+        commit = "0aec0327a6912e1a0ec5326eef737c2ce19bc836",
         # Repository-qualified on purpose: a bare `//external:pffft.BUILD`
         # resolves against the main repository rather than against the module
         # this file belongs to, so it breaks as soon as obr is consumed as a


### PR DESCRIPTION
## Summary

Pins `bitbucket.org/jpommier/pffft` to the same commit, 0aec032 (January 2026, the current head of that repository as of 4 September 2026), in both places OBR fetches it:

- `src/renderer/obr/obr_capi/obr/CMakeLists.txt` (`FetchContent`): was 180c2d6 (April 2024)
- `src/renderer/obr/obr_capi/obr/extensions.bzl` (Bazel `new_git_repository`): was d7a4c02 (February 2025)

Until now the CMake and Bazel builds compiled different pffft sources.

## What the update brings

Since the CMake pin: SIMD capability checks, an AltiVec guard, arm64ec on Windows, WASM SIMD, `long long` replaced by `size_t`, invalid-N validation in `pffft_new_setup`, the MSVC `/fp:strict` C2099 fix, and `_USE_MATH_DEFINES` handling.

Since the Bazel pin: twiddle factors computed in float with `cosf`/`sinf` instead of double `cos`/`sin`, an aligned-malloc fix for platforms with a narrow `size_t`, and const-qualified setup pointers in the API (OBR's non-const `PFFFT_Setup*` converts implicitly, no source change needed).

## Effect on output

The twiddle change shifts binaural output by up to 3.8e-5 absolute on the 8192-tap ambient and reverberant profiles and 7.6e-6 on the 256-tap direct profile, relative to builds from the old CMake pin. Measured with a harness modelled on `FftManager` / `PartitionedFftFilter` (3rd order, block sizes 64 to 1024, signal magnitude around 5). The two old pins produced bit-identical output, so CMake and Bazel builds shift by the same amount.

Accuracy against a long-double reference DFT is unchanged: relative RMS error of the forward real transform is 1.33e-7 at N=8192 with both the old and the new twiddles. Any bit-exact comparison against renders from the old CMake pin needs regenerated references.

Decoder block cost is unchanged within measurement noise (±3 %) on an Apple M5 Pro at every block size and profile.

## Verification

- Fresh CMake Release build with `-DOAR_BUILD_EXAMPLES=ON`: all 32 tests pass under `ctest -L 'oar|obr'` (24 OBR unit tests, 8 OAR example tests).
- `bazel build //:oar` succeeds; the fetched source is at the new commit.
